### PR TITLE
refactor(ci): use Go v1.22 as the minimum version in workflows

### DIFF
--- a/.anvil.lock
+++ b/.anvil.lock
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2024-02-11T11:57:06.339340104Z",
-  "version": "1.2.7",
+  "generated_at": "2024-02-22T13:19:09.352004026Z",
+  "version": "1.2.8",
   "files": [
     {
       "path": ".editorconfig"


### PR DESCRIPTION
Use Go v1.22 as the minimum version in workflows