### PR TITLE
chore(golangci): update golangci-lint to v.1.59.0

### DIFF
--- a/.anvil.lock
+++ b/.anvil.lock
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2024-03-31T17:06:54.758214211Z",
-  "version": "1.2.12",
+  "generated_at": "2024-06-04T17:11:19.850548293Z",
+  "version": "1.2.15",
   "files": [
     {
       "path": ".editorconfig"


### PR DESCRIPTION
Update golangci-lint to v1.59.0, see https://github.com/golangci/golangci-lint/releases/tag/v1.59.0