### PR TITLE
chore: update to Go v1.23, update golangci-lint to v1.60.1

### DIFF
--- a/.anvil.lock
+++ b/.anvil.lock
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2024-07-12T18:17:39.504114391Z",
-  "version": "1.2.19",
+  "generated_at": "2024-08-14T07:20:02.71674409Z",
+  "version": "1.2.20",
   "files": [
     {
       "path": ".editorconfig"


### PR DESCRIPTION
chore: update to Go v1.23, update golangci-lint to v1.60.1