### PR TITLE
Return newly created error

### DIFF
--- a/gen/template_webook_event.go
+++ b/gen/template_webook_event.go
@@ -245,7 +245,7 @@ func (g *EventHandler) HandleEventRequest(req *http.Request) error {
 	}
 	event, err := github.ParseWebHook(github.WebHookType(req), payload)
 	if err != nil {
-		return nfmt.Errorf("could not parse webhook: err=%s\n", err)
+		return fmt.Errorf("could not parse webhook: err=%s\n", err)
 	}
 
 	deliveryID := github.DeliveryID(req)

--- a/gen/template_webook_event.go
+++ b/gen/template_webook_event.go
@@ -241,13 +241,11 @@ func (g *EventHandler) handleError(deliveryID string, eventName string, event in
 func (g *EventHandler) HandleEventRequest(req *http.Request) error {
 	payload, err := github.ValidatePayload(req, []byte(g.WebhookSecret))
 	if err != nil {
-		fmt.Errorf("could not validate webhook payload: err=%s\n", err)
-		return err
+		return fmt.Errorf("could not validate webhook payload: err=%s\n", err)
 	}
 	event, err := github.ParseWebHook(github.WebHookType(req), payload)
 	if err != nil {
-		fmt.Errorf("could not parse webhook: err=%s\n", err)
-		return err
+		return nfmt.Errorf("could not parse webhook: err=%s\n", err)
 	}
 
 	deliveryID := github.DeliveryID(req)

--- a/githubevents/events.go
+++ b/githubevents/events.go
@@ -286,13 +286,11 @@ func (g *EventHandler) handleError(deliveryID string, eventName string, event in
 func (g *EventHandler) HandleEventRequest(req *http.Request) error {
 	payload, err := github.ValidatePayload(req, []byte(g.WebhookSecret))
 	if err != nil {
-		fmt.Errorf("could not validate webhook payload: err=%s\n", err)
-		return err
+		return fmt.Errorf("could not validate webhook payload: err=%s\n", err)
 	}
 	event, err := github.ParseWebHook(github.WebHookType(req), payload)
 	if err != nil {
-		fmt.Errorf("could not parse webhook: err=%s\n", err)
-		return err
+		return nfmt.Errorf("could not parse webhook: err=%s\n", err)
 	}
 
 	deliveryID := github.DeliveryID(req)

--- a/githubevents/events.go
+++ b/githubevents/events.go
@@ -290,7 +290,7 @@ func (g *EventHandler) HandleEventRequest(req *http.Request) error {
 	}
 	event, err := github.ParseWebHook(github.WebHookType(req), payload)
 	if err != nil {
-		return nfmt.Errorf("could not parse webhook: err=%s\n", err)
+		return fmt.Errorf("could not parse webhook: err=%s\n", err)
 	}
 
 	deliveryID := github.DeliveryID(req)


### PR DESCRIPTION
Previously, the newly created errors were not being returned.