### PR TITLE
deps: update golangci-lint to v1.63.4

### DIFF
--- a/.anvil.lock
+++ b/.anvil.lock
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2024-12-03T20:04:28.280328913Z",
-  "version": "1.2.24",
+  "generated_at": "2025-01-29T13:04:02.510519203Z",
+  "version": "1.2.25",
   "files": [
     {
       "path": ".editorconfig"


### PR DESCRIPTION
Updates golangci-lint to v1.63.4