### PR TITLE
refactor(templates): use .tmpl extension

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,4 +31,4 @@ build: \
 .PHONY: bin/gen
 bin/gen:
 	mkdir -p bin
-	$(GO) build -v -ldflags '-w $(LDFLAGS)' -o ./bin/githubhook-gen ./gen/*
+	$(GO) build -v -ldflags '-w $(LDFLAGS)' -o ./bin/githubhook-gen ./gen/*.go

--- a/gen/generate.go
+++ b/gen/generate.go
@@ -2,12 +2,25 @@ package main
 
 import (
 	"bytes"
+	_ "embed"
 	"flag"
 	"io"
 	"os"
 	"path/filepath"
 	"text/template"
 )
+
+//go:embed template_markdown.go.tmpl
+var webhookMarkdownTemplate string
+
+//go:embed template_webhook_event.go.tmpl
+var webhookEventTemplate string
+
+//go:embed template_webhook_event_tests.go.tmpl
+var webhookTestsTemplate string
+
+//go:embed template_webhook_event_types.go.tmpl
+var webhookTypesTemplate string
 
 func main() {
 	outputDir := flag.String("output", "githubevents", "output directory")

--- a/gen/template_markdown.go.tmpl
+++ b/gen/template_markdown.go.tmpl
@@ -1,7 +1,3 @@
-package main
-
-var webhookMarkdownTemplate = `
-
 {{ range $_, $webhook := .Webhooks }}
 * ***[{{ $webhook.Name }}](https://docs.github.com/en/developers/webhooks-and-events/webhooks/webhook-events-and-payloads#{{ $webhook.Name }})***
 {{ end }}

--- a/gen/template_webhook_event.go.tmpl
+++ b/gen/template_webhook_event.go.tmpl
@@ -1,6 +1,3 @@
-package main
-
-var webhookEventTemplate = `
 // Copyright 2022 The GithubEvents Authors. All rights reserved.
 // Use of this source code is governed by the MIT License
 // that can be found in the LICENSE file.
@@ -269,4 +266,3 @@ func (g *EventHandler) HandleEvent(deliveryID string, eventName string, event in
 func ptrString(s string) *string {
 	return &s
 }
-`

--- a/gen/template_webhook_event_tests.go.tmpl
+++ b/gen/template_webhook_event_tests.go.tmpl
@@ -1,6 +1,3 @@
-package main
-
-var webhookTestsTemplate = `
 // Copyright 2022 The GithubEvents Authors. All rights reserved.
 // Use of this source code is governed by the MIT License
 // that can be found in the LICENSE file.
@@ -582,4 +579,3 @@ func Test{{ $webhook.Event }}(t *testing.T) {
 }
 
 {{ end }}
-`

--- a/gen/template_webhook_event_types.go.tmpl
+++ b/gen/template_webhook_event_types.go.tmpl
@@ -1,6 +1,3 @@
-package main
-
-var webhookTypesTemplate = `
 // Copyright 2022 The GithubEvents Authors. All rights reserved.
 // Use of this source code is governed by the MIT License
 // that can be found in the LICENSE file.
@@ -253,4 +250,3 @@ func (g *EventHandler) {{ $webhook.Event }}(deliveryID string, eventName string,
 }
 
 {{ end }}
-`


### PR DESCRIPTION
This will allow rich editor integration.

This is following the go template naming convention.

See https://pkg.go.dev/text/template\#example-Template-Share

![image](https://github.com/user-attachments/assets/66fd4753-dc92-4fa7-b349-f13ae2e0b530)

What do you think ?

<!-- PLEASE READ BEFORE DELETING

Before proceeding, ensure your pull request is targeting the main branch. Clearly describe the purpose of your pull request and the issue it addresses, if applicable. We also encourage you to read our contributing guidelines for a smoother contribution process:

  https://github.com/cbrgm/githubevents/blob/main/CONTRIBUTING.md

Thank you for your contribution!

-->
