### PR TITLE
fix: recover from panic in handlers

### DIFF
--- a/gen/template_webhook_event.go.tmpl
+++ b/gen/template_webhook_event.go.tmpl
@@ -99,8 +99,13 @@ func (g *EventHandler) handleBeforeAny(ctx context.Context, deliveryID string, e
 	eg := new(errgroup.Group)
 	for _, h := range g.onBeforeAny[EventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}
@@ -158,8 +163,13 @@ func (g *EventHandler) handleAfterAny(ctx context.Context, deliveryID string, ev
 	eg := new(errgroup.Group)
 	for _, h := range g.onAfterAny[EventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}
@@ -221,8 +231,13 @@ func (g *EventHandler) handleError(ctx context.Context, deliveryID string, event
 	eg := new(errgroup.Group)
 	for _, h := range g.onErrorAny[EventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event, err)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event, err)
 			if err != nil {
 				return err
 			}

--- a/gen/template_webhook_event_tests.go.tmpl
+++ b/gen/template_webhook_event_tests.go.tmpl
@@ -120,6 +120,7 @@ func TestHandle{{ $webhook.Event }}Any(t *testing.T) {
 		eventName  string
 		event      *github.{{ $webhook.Event }}
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -155,6 +156,21 @@ func TestHandle{{ $webhook.Event }}Any(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "{{ $webhook.Name }}",
+				{{ if $webhook.HasActions }}
+				event:    &github.{{ $webhook.Event }}{Action: &action},
+				{{ else }}
+				event:    &github.{{ $webhook.Event }}{},
+				{{ end }}
+				fail:     false,
+				panic: 	  true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -171,6 +187,9 @@ func TestHandle{{ $webhook.Event }}Any(t *testing.T) {
 			g.On{{ $webhook.Event }}Any(func(ctx context.Context, deliveryID string, eventName string, event *github.{{ $webhook.Event }}) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -287,6 +306,7 @@ func TestHandle{{ $action.Handler }}(t *testing.T) {
 		eventName  string
 		event      *github.{{ $webhook.Event }}
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -310,6 +330,17 @@ func TestHandle{{ $action.Handler }}(t *testing.T) {
 				eventName:  "{{ $webhook.Name }}",
 				event:      &github.{{ $webhook.Event }}{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "{{ $webhook.Name }}",
+				event:      &github.{{ $webhook.Event }}{Action: &action},
+				fail:       false,
+				panic: 		true,
 			},
 			wantErr: true,
 		},
@@ -360,6 +391,9 @@ func TestHandle{{ $action.Handler }}(t *testing.T) {
 			g.On{{ $action.Handler }}(func(ctx context.Context, deliveryID string, eventName string, event *github.{{ $webhook.Event }}) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/gen/template_webhook_event_types.go.tmpl
+++ b/gen/template_webhook_event_types.go.tmpl
@@ -104,8 +104,13 @@ func (g *EventHandler) handle{{ $action.Handler }}(ctx context.Context, delivery
 		if _, ok := g.on{{ $webhook.Event }}[action]; ok {
 			for _, h := range g.on{{ $webhook.Event }}[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -178,8 +183,13 @@ func (g *EventHandler) handle{{ $webhook.Event }}Any(ctx context.Context, delive
 	eg := new(errgroup.Group)
 	for _, h := range g.on{{ $webhook.Event }}[{{ $webhook.Event }}AnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events.go
+++ b/githubevents/events.go
@@ -147,8 +147,13 @@ func (g *EventHandler) handleBeforeAny(ctx context.Context, deliveryID string, e
 	eg := new(errgroup.Group)
 	for _, h := range g.onBeforeAny[EventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}
@@ -206,8 +211,13 @@ func (g *EventHandler) handleAfterAny(ctx context.Context, deliveryID string, ev
 	eg := new(errgroup.Group)
 	for _, h := range g.onAfterAny[EventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}
@@ -269,8 +279,13 @@ func (g *EventHandler) handleError(ctx context.Context, deliveryID string, event
 	eg := new(errgroup.Group)
 	for _, h := range g.onErrorAny[EventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event, err)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event, err)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_branch_protection_rule.go
+++ b/githubevents/events_branch_protection_rule.go
@@ -107,8 +107,13 @@ func (g *EventHandler) handleBranchProtectionRuleEventCreated(ctx context.Contex
 		if _, ok := g.onBranchProtectionRuleEvent[action]; ok {
 			for _, h := range g.onBranchProtectionRuleEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -188,8 +193,13 @@ func (g *EventHandler) handleBranchProtectionRuleEventEdited(ctx context.Context
 		if _, ok := g.onBranchProtectionRuleEvent[action]; ok {
 			for _, h := range g.onBranchProtectionRuleEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -269,8 +279,13 @@ func (g *EventHandler) handleBranchProtectionRuleEventDeleted(ctx context.Contex
 		if _, ok := g.onBranchProtectionRuleEvent[action]; ok {
 			for _, h := range g.onBranchProtectionRuleEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -341,8 +356,13 @@ func (g *EventHandler) handleBranchProtectionRuleEventAny(ctx context.Context, d
 	eg := new(errgroup.Group)
 	for _, h := range g.onBranchProtectionRuleEvent[BranchProtectionRuleEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_branch_protection_rule_test.go
+++ b/githubevents/events_branch_protection_rule_test.go
@@ -117,6 +117,7 @@ func TestHandleBranchProtectionRuleEventAny(t *testing.T) {
 		eventName  string
 		event      *github.BranchProtectionRuleEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandleBranchProtectionRuleEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "branch_protection_rule",
+
+				event: &github.BranchProtectionRuleEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandleBranchProtectionRuleEventAny(t *testing.T) {
 			g.OnBranchProtectionRuleEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.BranchProtectionRuleEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandleBranchProtectionRuleEventCreated(t *testing.T) {
 		eventName  string
 		event      *github.BranchProtectionRuleEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandleBranchProtectionRuleEventCreated(t *testing.T) {
 				eventName:  "branch_protection_rule",
 				event:      &github.BranchProtectionRuleEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "branch_protection_rule",
+				event:      &github.BranchProtectionRuleEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandleBranchProtectionRuleEventCreated(t *testing.T) {
 			g.OnBranchProtectionRuleEventCreated(func(ctx context.Context, deliveryID string, eventName string, event *github.BranchProtectionRuleEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandleBranchProtectionRuleEventEdited(t *testing.T) {
 		eventName  string
 		event      *github.BranchProtectionRuleEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandleBranchProtectionRuleEventEdited(t *testing.T) {
 				eventName:  "branch_protection_rule",
 				event:      &github.BranchProtectionRuleEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "branch_protection_rule",
+				event:      &github.BranchProtectionRuleEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandleBranchProtectionRuleEventEdited(t *testing.T) {
 			g.OnBranchProtectionRuleEventEdited(func(ctx context.Context, deliveryID string, eventName string, event *github.BranchProtectionRuleEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -652,6 +699,7 @@ func TestHandleBranchProtectionRuleEventDeleted(t *testing.T) {
 		eventName  string
 		event      *github.BranchProtectionRuleEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -675,6 +723,17 @@ func TestHandleBranchProtectionRuleEventDeleted(t *testing.T) {
 				eventName:  "branch_protection_rule",
 				event:      &github.BranchProtectionRuleEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "branch_protection_rule",
+				event:      &github.BranchProtectionRuleEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -725,6 +784,9 @@ func TestHandleBranchProtectionRuleEventDeleted(t *testing.T) {
 			g.OnBranchProtectionRuleEventDeleted(func(ctx context.Context, deliveryID string, eventName string, event *github.BranchProtectionRuleEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_check_run.go
+++ b/githubevents/events_check_run.go
@@ -111,8 +111,13 @@ func (g *EventHandler) handleCheckRunEventCreated(ctx context.Context, deliveryI
 		if _, ok := g.onCheckRunEvent[action]; ok {
 			for _, h := range g.onCheckRunEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -192,8 +197,13 @@ func (g *EventHandler) handleCheckRunEventCompleted(ctx context.Context, deliver
 		if _, ok := g.onCheckRunEvent[action]; ok {
 			for _, h := range g.onCheckRunEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -273,8 +283,13 @@ func (g *EventHandler) handleCheckRunEventReRequested(ctx context.Context, deliv
 		if _, ok := g.onCheckRunEvent[action]; ok {
 			for _, h := range g.onCheckRunEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -354,8 +369,13 @@ func (g *EventHandler) handleCheckRunEventRequestAction(ctx context.Context, del
 		if _, ok := g.onCheckRunEvent[action]; ok {
 			for _, h := range g.onCheckRunEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -426,8 +446,13 @@ func (g *EventHandler) handleCheckRunEventAny(ctx context.Context, deliveryID st
 	eg := new(errgroup.Group)
 	for _, h := range g.onCheckRunEvent[CheckRunEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_check_run_test.go
+++ b/githubevents/events_check_run_test.go
@@ -117,6 +117,7 @@ func TestHandleCheckRunEventAny(t *testing.T) {
 		eventName  string
 		event      *github.CheckRunEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandleCheckRunEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "check_run",
+
+				event: &github.CheckRunEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandleCheckRunEventAny(t *testing.T) {
 			g.OnCheckRunEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.CheckRunEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandleCheckRunEventCreated(t *testing.T) {
 		eventName  string
 		event      *github.CheckRunEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandleCheckRunEventCreated(t *testing.T) {
 				eventName:  "check_run",
 				event:      &github.CheckRunEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "check_run",
+				event:      &github.CheckRunEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandleCheckRunEventCreated(t *testing.T) {
 			g.OnCheckRunEventCreated(func(ctx context.Context, deliveryID string, eventName string, event *github.CheckRunEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandleCheckRunEventCompleted(t *testing.T) {
 		eventName  string
 		event      *github.CheckRunEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandleCheckRunEventCompleted(t *testing.T) {
 				eventName:  "check_run",
 				event:      &github.CheckRunEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "check_run",
+				event:      &github.CheckRunEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandleCheckRunEventCompleted(t *testing.T) {
 			g.OnCheckRunEventCompleted(func(ctx context.Context, deliveryID string, eventName string, event *github.CheckRunEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -652,6 +699,7 @@ func TestHandleCheckRunEventReRequested(t *testing.T) {
 		eventName  string
 		event      *github.CheckRunEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -675,6 +723,17 @@ func TestHandleCheckRunEventReRequested(t *testing.T) {
 				eventName:  "check_run",
 				event:      &github.CheckRunEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "check_run",
+				event:      &github.CheckRunEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -725,6 +784,9 @@ func TestHandleCheckRunEventReRequested(t *testing.T) {
 			g.OnCheckRunEventReRequested(func(ctx context.Context, deliveryID string, eventName string, event *github.CheckRunEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -839,6 +901,7 @@ func TestHandleCheckRunEventRequestAction(t *testing.T) {
 		eventName  string
 		event      *github.CheckRunEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -862,6 +925,17 @@ func TestHandleCheckRunEventRequestAction(t *testing.T) {
 				eventName:  "check_run",
 				event:      &github.CheckRunEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "check_run",
+				event:      &github.CheckRunEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -912,6 +986,9 @@ func TestHandleCheckRunEventRequestAction(t *testing.T) {
 			g.OnCheckRunEventRequestAction(func(ctx context.Context, deliveryID string, eventName string, event *github.CheckRunEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_check_suite.go
+++ b/githubevents/events_check_suite.go
@@ -107,8 +107,13 @@ func (g *EventHandler) handleCheckSuiteEventCompleted(ctx context.Context, deliv
 		if _, ok := g.onCheckSuiteEvent[action]; ok {
 			for _, h := range g.onCheckSuiteEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -188,8 +193,13 @@ func (g *EventHandler) handleCheckSuiteEventRequested(ctx context.Context, deliv
 		if _, ok := g.onCheckSuiteEvent[action]; ok {
 			for _, h := range g.onCheckSuiteEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -269,8 +279,13 @@ func (g *EventHandler) handleCheckSuiteEventReRequested(ctx context.Context, del
 		if _, ok := g.onCheckSuiteEvent[action]; ok {
 			for _, h := range g.onCheckSuiteEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -341,8 +356,13 @@ func (g *EventHandler) handleCheckSuiteEventAny(ctx context.Context, deliveryID 
 	eg := new(errgroup.Group)
 	for _, h := range g.onCheckSuiteEvent[CheckSuiteEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_check_suite_test.go
+++ b/githubevents/events_check_suite_test.go
@@ -117,6 +117,7 @@ func TestHandleCheckSuiteEventAny(t *testing.T) {
 		eventName  string
 		event      *github.CheckSuiteEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandleCheckSuiteEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "check_suite",
+
+				event: &github.CheckSuiteEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandleCheckSuiteEventAny(t *testing.T) {
 			g.OnCheckSuiteEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.CheckSuiteEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandleCheckSuiteEventCompleted(t *testing.T) {
 		eventName  string
 		event      *github.CheckSuiteEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandleCheckSuiteEventCompleted(t *testing.T) {
 				eventName:  "check_suite",
 				event:      &github.CheckSuiteEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "check_suite",
+				event:      &github.CheckSuiteEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandleCheckSuiteEventCompleted(t *testing.T) {
 			g.OnCheckSuiteEventCompleted(func(ctx context.Context, deliveryID string, eventName string, event *github.CheckSuiteEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandleCheckSuiteEventRequested(t *testing.T) {
 		eventName  string
 		event      *github.CheckSuiteEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandleCheckSuiteEventRequested(t *testing.T) {
 				eventName:  "check_suite",
 				event:      &github.CheckSuiteEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "check_suite",
+				event:      &github.CheckSuiteEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandleCheckSuiteEventRequested(t *testing.T) {
 			g.OnCheckSuiteEventRequested(func(ctx context.Context, deliveryID string, eventName string, event *github.CheckSuiteEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -652,6 +699,7 @@ func TestHandleCheckSuiteEventReRequested(t *testing.T) {
 		eventName  string
 		event      *github.CheckSuiteEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -675,6 +723,17 @@ func TestHandleCheckSuiteEventReRequested(t *testing.T) {
 				eventName:  "check_suite",
 				event:      &github.CheckSuiteEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "check_suite",
+				event:      &github.CheckSuiteEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -725,6 +784,9 @@ func TestHandleCheckSuiteEventReRequested(t *testing.T) {
 			g.OnCheckSuiteEventReRequested(func(ctx context.Context, deliveryID string, eventName string, event *github.CheckSuiteEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_commit_comment.go
+++ b/githubevents/events_commit_comment.go
@@ -99,8 +99,13 @@ func (g *EventHandler) handleCommitCommentEventCreated(ctx context.Context, deli
 		if _, ok := g.onCommitCommentEvent[action]; ok {
 			for _, h := range g.onCommitCommentEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -171,8 +176,13 @@ func (g *EventHandler) handleCommitCommentEventAny(ctx context.Context, delivery
 	eg := new(errgroup.Group)
 	for _, h := range g.onCommitCommentEvent[CommitCommentEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_commit_comment_test.go
+++ b/githubevents/events_commit_comment_test.go
@@ -117,6 +117,7 @@ func TestHandleCommitCommentEventAny(t *testing.T) {
 		eventName  string
 		event      *github.CommitCommentEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandleCommitCommentEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "commit_comment",
+
+				event: &github.CommitCommentEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandleCommitCommentEventAny(t *testing.T) {
 			g.OnCommitCommentEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.CommitCommentEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandleCommitCommentEventCreated(t *testing.T) {
 		eventName  string
 		event      *github.CommitCommentEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandleCommitCommentEventCreated(t *testing.T) {
 				eventName:  "commit_comment",
 				event:      &github.CommitCommentEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "commit_comment",
+				event:      &github.CommitCommentEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandleCommitCommentEventCreated(t *testing.T) {
 			g.OnCommitCommentEventCreated(func(ctx context.Context, deliveryID string, eventName string, event *github.CommitCommentEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_create.go
+++ b/githubevents/events_create.go
@@ -86,8 +86,13 @@ func (g *EventHandler) handleCreateEventAny(ctx context.Context, deliveryID stri
 	eg := new(errgroup.Group)
 	for _, h := range g.onCreateEvent[CreateEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_create_test.go
+++ b/githubevents/events_create_test.go
@@ -115,6 +115,7 @@ func TestHandleCreateEventAny(t *testing.T) {
 		eventName  string
 		event      *github.CreateEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -146,6 +147,19 @@ func TestHandleCreateEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "create",
+
+				event: &github.CreateEvent{},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -162,6 +176,9 @@ func TestHandleCreateEventAny(t *testing.T) {
 			g.OnCreateEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.CreateEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_delete.go
+++ b/githubevents/events_delete.go
@@ -86,8 +86,13 @@ func (g *EventHandler) handleDeleteEventAny(ctx context.Context, deliveryID stri
 	eg := new(errgroup.Group)
 	for _, h := range g.onDeleteEvent[DeleteEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_delete_test.go
+++ b/githubevents/events_delete_test.go
@@ -115,6 +115,7 @@ func TestHandleDeleteEventAny(t *testing.T) {
 		eventName  string
 		event      *github.DeleteEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -146,6 +147,19 @@ func TestHandleDeleteEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "delete",
+
+				event: &github.DeleteEvent{},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -162,6 +176,9 @@ func TestHandleDeleteEventAny(t *testing.T) {
 			g.OnDeleteEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.DeleteEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_deploy_key.go
+++ b/githubevents/events_deploy_key.go
@@ -103,8 +103,13 @@ func (g *EventHandler) handleDeployKeyEventCreated(ctx context.Context, delivery
 		if _, ok := g.onDeployKeyEvent[action]; ok {
 			for _, h := range g.onDeployKeyEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -184,8 +189,13 @@ func (g *EventHandler) handleDeployKeyEventDeleted(ctx context.Context, delivery
 		if _, ok := g.onDeployKeyEvent[action]; ok {
 			for _, h := range g.onDeployKeyEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -256,8 +266,13 @@ func (g *EventHandler) handleDeployKeyEventAny(ctx context.Context, deliveryID s
 	eg := new(errgroup.Group)
 	for _, h := range g.onDeployKeyEvent[DeployKeyEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_deploy_key_test.go
+++ b/githubevents/events_deploy_key_test.go
@@ -117,6 +117,7 @@ func TestHandleDeployKeyEventAny(t *testing.T) {
 		eventName  string
 		event      *github.DeployKeyEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandleDeployKeyEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "deploy_key",
+
+				event: &github.DeployKeyEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandleDeployKeyEventAny(t *testing.T) {
 			g.OnDeployKeyEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.DeployKeyEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandleDeployKeyEventCreated(t *testing.T) {
 		eventName  string
 		event      *github.DeployKeyEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandleDeployKeyEventCreated(t *testing.T) {
 				eventName:  "deploy_key",
 				event:      &github.DeployKeyEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "deploy_key",
+				event:      &github.DeployKeyEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandleDeployKeyEventCreated(t *testing.T) {
 			g.OnDeployKeyEventCreated(func(ctx context.Context, deliveryID string, eventName string, event *github.DeployKeyEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandleDeployKeyEventDeleted(t *testing.T) {
 		eventName  string
 		event      *github.DeployKeyEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandleDeployKeyEventDeleted(t *testing.T) {
 				eventName:  "deploy_key",
 				event:      &github.DeployKeyEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "deploy_key",
+				event:      &github.DeployKeyEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandleDeployKeyEventDeleted(t *testing.T) {
 			g.OnDeployKeyEventDeleted(func(ctx context.Context, deliveryID string, eventName string, event *github.DeployKeyEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_deployment.go
+++ b/githubevents/events_deployment.go
@@ -86,8 +86,13 @@ func (g *EventHandler) handleDeploymentEventAny(ctx context.Context, deliveryID 
 	eg := new(errgroup.Group)
 	for _, h := range g.onDeploymentEvent[DeploymentEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_deployment_status.go
+++ b/githubevents/events_deployment_status.go
@@ -86,8 +86,13 @@ func (g *EventHandler) handleDeploymentStatusEventAny(ctx context.Context, deliv
 	eg := new(errgroup.Group)
 	for _, h := range g.onDeploymentStatusEvent[DeploymentStatusEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_deployment_status_test.go
+++ b/githubevents/events_deployment_status_test.go
@@ -115,6 +115,7 @@ func TestHandleDeploymentStatusEventAny(t *testing.T) {
 		eventName  string
 		event      *github.DeploymentStatusEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -146,6 +147,19 @@ func TestHandleDeploymentStatusEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "deployment_status",
+
+				event: &github.DeploymentStatusEvent{},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -162,6 +176,9 @@ func TestHandleDeploymentStatusEventAny(t *testing.T) {
 			g.OnDeploymentStatusEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.DeploymentStatusEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_deployment_test.go
+++ b/githubevents/events_deployment_test.go
@@ -115,6 +115,7 @@ func TestHandleDeploymentEventAny(t *testing.T) {
 		eventName  string
 		event      *github.DeploymentEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -146,6 +147,19 @@ func TestHandleDeploymentEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "deployment",
+
+				event: &github.DeploymentEvent{},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -162,6 +176,9 @@ func TestHandleDeploymentEventAny(t *testing.T) {
 			g.OnDeploymentEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.DeploymentEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_discussion.go
+++ b/githubevents/events_discussion.go
@@ -147,8 +147,13 @@ func (g *EventHandler) handleDiscussionEventCreated(ctx context.Context, deliver
 		if _, ok := g.onDiscussionEvent[action]; ok {
 			for _, h := range g.onDiscussionEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -228,8 +233,13 @@ func (g *EventHandler) handleDiscussionEventEdited(ctx context.Context, delivery
 		if _, ok := g.onDiscussionEvent[action]; ok {
 			for _, h := range g.onDiscussionEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -309,8 +319,13 @@ func (g *EventHandler) handleDiscussionEventDeleted(ctx context.Context, deliver
 		if _, ok := g.onDiscussionEvent[action]; ok {
 			for _, h := range g.onDiscussionEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -390,8 +405,13 @@ func (g *EventHandler) handleDiscussionEventPinned(ctx context.Context, delivery
 		if _, ok := g.onDiscussionEvent[action]; ok {
 			for _, h := range g.onDiscussionEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -471,8 +491,13 @@ func (g *EventHandler) handleDiscussionEventUnpinned(ctx context.Context, delive
 		if _, ok := g.onDiscussionEvent[action]; ok {
 			for _, h := range g.onDiscussionEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -552,8 +577,13 @@ func (g *EventHandler) handleDiscussionEventLocked(ctx context.Context, delivery
 		if _, ok := g.onDiscussionEvent[action]; ok {
 			for _, h := range g.onDiscussionEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -633,8 +663,13 @@ func (g *EventHandler) handleDiscussionEventUnlocked(ctx context.Context, delive
 		if _, ok := g.onDiscussionEvent[action]; ok {
 			for _, h := range g.onDiscussionEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -714,8 +749,13 @@ func (g *EventHandler) handleDiscussionEventTransferred(ctx context.Context, del
 		if _, ok := g.onDiscussionEvent[action]; ok {
 			for _, h := range g.onDiscussionEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -795,8 +835,13 @@ func (g *EventHandler) handleDiscussionEventCategoryChanged(ctx context.Context,
 		if _, ok := g.onDiscussionEvent[action]; ok {
 			for _, h := range g.onDiscussionEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -876,8 +921,13 @@ func (g *EventHandler) handleDiscussionEventAnswered(ctx context.Context, delive
 		if _, ok := g.onDiscussionEvent[action]; ok {
 			for _, h := range g.onDiscussionEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -957,8 +1007,13 @@ func (g *EventHandler) handleDiscussionEventUnanswered(ctx context.Context, deli
 		if _, ok := g.onDiscussionEvent[action]; ok {
 			for _, h := range g.onDiscussionEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -1038,8 +1093,13 @@ func (g *EventHandler) handleDiscussionEventLabeled(ctx context.Context, deliver
 		if _, ok := g.onDiscussionEvent[action]; ok {
 			for _, h := range g.onDiscussionEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -1119,8 +1179,13 @@ func (g *EventHandler) handleDiscussionEventUnlabeled(ctx context.Context, deliv
 		if _, ok := g.onDiscussionEvent[action]; ok {
 			for _, h := range g.onDiscussionEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -1191,8 +1256,13 @@ func (g *EventHandler) handleDiscussionEventAny(ctx context.Context, deliveryID 
 	eg := new(errgroup.Group)
 	for _, h := range g.onDiscussionEvent[DiscussionEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_discussion_test.go
+++ b/githubevents/events_discussion_test.go
@@ -117,6 +117,7 @@ func TestHandleDiscussionEventAny(t *testing.T) {
 		eventName  string
 		event      *github.DiscussionEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandleDiscussionEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "discussion",
+
+				event: &github.DiscussionEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandleDiscussionEventAny(t *testing.T) {
 			g.OnDiscussionEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.DiscussionEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandleDiscussionEventCreated(t *testing.T) {
 		eventName  string
 		event      *github.DiscussionEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandleDiscussionEventCreated(t *testing.T) {
 				eventName:  "discussion",
 				event:      &github.DiscussionEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "discussion",
+				event:      &github.DiscussionEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandleDiscussionEventCreated(t *testing.T) {
 			g.OnDiscussionEventCreated(func(ctx context.Context, deliveryID string, eventName string, event *github.DiscussionEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandleDiscussionEventEdited(t *testing.T) {
 		eventName  string
 		event      *github.DiscussionEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandleDiscussionEventEdited(t *testing.T) {
 				eventName:  "discussion",
 				event:      &github.DiscussionEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "discussion",
+				event:      &github.DiscussionEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandleDiscussionEventEdited(t *testing.T) {
 			g.OnDiscussionEventEdited(func(ctx context.Context, deliveryID string, eventName string, event *github.DiscussionEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -652,6 +699,7 @@ func TestHandleDiscussionEventDeleted(t *testing.T) {
 		eventName  string
 		event      *github.DiscussionEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -675,6 +723,17 @@ func TestHandleDiscussionEventDeleted(t *testing.T) {
 				eventName:  "discussion",
 				event:      &github.DiscussionEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "discussion",
+				event:      &github.DiscussionEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -725,6 +784,9 @@ func TestHandleDiscussionEventDeleted(t *testing.T) {
 			g.OnDiscussionEventDeleted(func(ctx context.Context, deliveryID string, eventName string, event *github.DiscussionEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -839,6 +901,7 @@ func TestHandleDiscussionEventPinned(t *testing.T) {
 		eventName  string
 		event      *github.DiscussionEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -862,6 +925,17 @@ func TestHandleDiscussionEventPinned(t *testing.T) {
 				eventName:  "discussion",
 				event:      &github.DiscussionEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "discussion",
+				event:      &github.DiscussionEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -912,6 +986,9 @@ func TestHandleDiscussionEventPinned(t *testing.T) {
 			g.OnDiscussionEventPinned(func(ctx context.Context, deliveryID string, eventName string, event *github.DiscussionEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1026,6 +1103,7 @@ func TestHandleDiscussionEventUnpinned(t *testing.T) {
 		eventName  string
 		event      *github.DiscussionEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1049,6 +1127,17 @@ func TestHandleDiscussionEventUnpinned(t *testing.T) {
 				eventName:  "discussion",
 				event:      &github.DiscussionEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "discussion",
+				event:      &github.DiscussionEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1099,6 +1188,9 @@ func TestHandleDiscussionEventUnpinned(t *testing.T) {
 			g.OnDiscussionEventUnpinned(func(ctx context.Context, deliveryID string, eventName string, event *github.DiscussionEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1213,6 +1305,7 @@ func TestHandleDiscussionEventLocked(t *testing.T) {
 		eventName  string
 		event      *github.DiscussionEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1236,6 +1329,17 @@ func TestHandleDiscussionEventLocked(t *testing.T) {
 				eventName:  "discussion",
 				event:      &github.DiscussionEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "discussion",
+				event:      &github.DiscussionEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1286,6 +1390,9 @@ func TestHandleDiscussionEventLocked(t *testing.T) {
 			g.OnDiscussionEventLocked(func(ctx context.Context, deliveryID string, eventName string, event *github.DiscussionEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1400,6 +1507,7 @@ func TestHandleDiscussionEventUnlocked(t *testing.T) {
 		eventName  string
 		event      *github.DiscussionEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1423,6 +1531,17 @@ func TestHandleDiscussionEventUnlocked(t *testing.T) {
 				eventName:  "discussion",
 				event:      &github.DiscussionEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "discussion",
+				event:      &github.DiscussionEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1473,6 +1592,9 @@ func TestHandleDiscussionEventUnlocked(t *testing.T) {
 			g.OnDiscussionEventUnlocked(func(ctx context.Context, deliveryID string, eventName string, event *github.DiscussionEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1587,6 +1709,7 @@ func TestHandleDiscussionEventTransferred(t *testing.T) {
 		eventName  string
 		event      *github.DiscussionEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1610,6 +1733,17 @@ func TestHandleDiscussionEventTransferred(t *testing.T) {
 				eventName:  "discussion",
 				event:      &github.DiscussionEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "discussion",
+				event:      &github.DiscussionEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1660,6 +1794,9 @@ func TestHandleDiscussionEventTransferred(t *testing.T) {
 			g.OnDiscussionEventTransferred(func(ctx context.Context, deliveryID string, eventName string, event *github.DiscussionEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1774,6 +1911,7 @@ func TestHandleDiscussionEventCategoryChanged(t *testing.T) {
 		eventName  string
 		event      *github.DiscussionEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1797,6 +1935,17 @@ func TestHandleDiscussionEventCategoryChanged(t *testing.T) {
 				eventName:  "discussion",
 				event:      &github.DiscussionEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "discussion",
+				event:      &github.DiscussionEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1847,6 +1996,9 @@ func TestHandleDiscussionEventCategoryChanged(t *testing.T) {
 			g.OnDiscussionEventCategoryChanged(func(ctx context.Context, deliveryID string, eventName string, event *github.DiscussionEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1961,6 +2113,7 @@ func TestHandleDiscussionEventAnswered(t *testing.T) {
 		eventName  string
 		event      *github.DiscussionEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1984,6 +2137,17 @@ func TestHandleDiscussionEventAnswered(t *testing.T) {
 				eventName:  "discussion",
 				event:      &github.DiscussionEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "discussion",
+				event:      &github.DiscussionEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -2034,6 +2198,9 @@ func TestHandleDiscussionEventAnswered(t *testing.T) {
 			g.OnDiscussionEventAnswered(func(ctx context.Context, deliveryID string, eventName string, event *github.DiscussionEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -2148,6 +2315,7 @@ func TestHandleDiscussionEventUnanswered(t *testing.T) {
 		eventName  string
 		event      *github.DiscussionEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -2171,6 +2339,17 @@ func TestHandleDiscussionEventUnanswered(t *testing.T) {
 				eventName:  "discussion",
 				event:      &github.DiscussionEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "discussion",
+				event:      &github.DiscussionEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -2221,6 +2400,9 @@ func TestHandleDiscussionEventUnanswered(t *testing.T) {
 			g.OnDiscussionEventUnanswered(func(ctx context.Context, deliveryID string, eventName string, event *github.DiscussionEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -2335,6 +2517,7 @@ func TestHandleDiscussionEventLabeled(t *testing.T) {
 		eventName  string
 		event      *github.DiscussionEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -2358,6 +2541,17 @@ func TestHandleDiscussionEventLabeled(t *testing.T) {
 				eventName:  "discussion",
 				event:      &github.DiscussionEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "discussion",
+				event:      &github.DiscussionEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -2408,6 +2602,9 @@ func TestHandleDiscussionEventLabeled(t *testing.T) {
 			g.OnDiscussionEventLabeled(func(ctx context.Context, deliveryID string, eventName string, event *github.DiscussionEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -2522,6 +2719,7 @@ func TestHandleDiscussionEventUnlabeled(t *testing.T) {
 		eventName  string
 		event      *github.DiscussionEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -2545,6 +2743,17 @@ func TestHandleDiscussionEventUnlabeled(t *testing.T) {
 				eventName:  "discussion",
 				event:      &github.DiscussionEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "discussion",
+				event:      &github.DiscussionEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -2595,6 +2804,9 @@ func TestHandleDiscussionEventUnlabeled(t *testing.T) {
 			g.OnDiscussionEventUnlabeled(func(ctx context.Context, deliveryID string, eventName string, event *github.DiscussionEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_fork.go
+++ b/githubevents/events_fork.go
@@ -86,8 +86,13 @@ func (g *EventHandler) handleForkEventAny(ctx context.Context, deliveryID string
 	eg := new(errgroup.Group)
 	for _, h := range g.onForkEvent[ForkEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_fork_test.go
+++ b/githubevents/events_fork_test.go
@@ -115,6 +115,7 @@ func TestHandleForkEventAny(t *testing.T) {
 		eventName  string
 		event      *github.ForkEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -146,6 +147,19 @@ func TestHandleForkEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "fork",
+
+				event: &github.ForkEvent{},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -162,6 +176,9 @@ func TestHandleForkEventAny(t *testing.T) {
 			g.OnForkEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.ForkEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_github_app_authorization.go
+++ b/githubevents/events_github_app_authorization.go
@@ -99,8 +99,13 @@ func (g *EventHandler) handleGitHubAppAuthorizationEventRevoked(ctx context.Cont
 		if _, ok := g.onGitHubAppAuthorizationEvent[action]; ok {
 			for _, h := range g.onGitHubAppAuthorizationEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -171,8 +176,13 @@ func (g *EventHandler) handleGitHubAppAuthorizationEventAny(ctx context.Context,
 	eg := new(errgroup.Group)
 	for _, h := range g.onGitHubAppAuthorizationEvent[GitHubAppAuthorizationEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_github_app_authorization_test.go
+++ b/githubevents/events_github_app_authorization_test.go
@@ -117,6 +117,7 @@ func TestHandleGitHubAppAuthorizationEventAny(t *testing.T) {
 		eventName  string
 		event      *github.GitHubAppAuthorizationEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandleGitHubAppAuthorizationEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "github_app_authorization",
+
+				event: &github.GitHubAppAuthorizationEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandleGitHubAppAuthorizationEventAny(t *testing.T) {
 			g.OnGitHubAppAuthorizationEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.GitHubAppAuthorizationEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandleGitHubAppAuthorizationEventRevoked(t *testing.T) {
 		eventName  string
 		event      *github.GitHubAppAuthorizationEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandleGitHubAppAuthorizationEventRevoked(t *testing.T) {
 				eventName:  "github_app_authorization",
 				event:      &github.GitHubAppAuthorizationEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "github_app_authorization",
+				event:      &github.GitHubAppAuthorizationEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandleGitHubAppAuthorizationEventRevoked(t *testing.T) {
 			g.OnGitHubAppAuthorizationEventRevoked(func(ctx context.Context, deliveryID string, eventName string, event *github.GitHubAppAuthorizationEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_gollum.go
+++ b/githubevents/events_gollum.go
@@ -86,8 +86,13 @@ func (g *EventHandler) handleGollumEventAny(ctx context.Context, deliveryID stri
 	eg := new(errgroup.Group)
 	for _, h := range g.onGollumEvent[GollumEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_gollum_test.go
+++ b/githubevents/events_gollum_test.go
@@ -115,6 +115,7 @@ func TestHandleGollumEventAny(t *testing.T) {
 		eventName  string
 		event      *github.GollumEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -146,6 +147,19 @@ func TestHandleGollumEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "gollum",
+
+				event: &github.GollumEvent{},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -162,6 +176,9 @@ func TestHandleGollumEventAny(t *testing.T) {
 			g.OnGollumEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.GollumEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_installation.go
+++ b/githubevents/events_installation.go
@@ -115,8 +115,13 @@ func (g *EventHandler) handleInstallationEventCreated(ctx context.Context, deliv
 		if _, ok := g.onInstallationEvent[action]; ok {
 			for _, h := range g.onInstallationEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -196,8 +201,13 @@ func (g *EventHandler) handleInstallationEventDeleted(ctx context.Context, deliv
 		if _, ok := g.onInstallationEvent[action]; ok {
 			for _, h := range g.onInstallationEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -277,8 +287,13 @@ func (g *EventHandler) handleInstallationEventEventSuspend(ctx context.Context, 
 		if _, ok := g.onInstallationEvent[action]; ok {
 			for _, h := range g.onInstallationEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -358,8 +373,13 @@ func (g *EventHandler) handleInstallationEventEventUnsuspend(ctx context.Context
 		if _, ok := g.onInstallationEvent[action]; ok {
 			for _, h := range g.onInstallationEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -439,8 +459,13 @@ func (g *EventHandler) handleInstallationEventNewPermissionsAccepted(ctx context
 		if _, ok := g.onInstallationEvent[action]; ok {
 			for _, h := range g.onInstallationEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -511,8 +536,13 @@ func (g *EventHandler) handleInstallationEventAny(ctx context.Context, deliveryI
 	eg := new(errgroup.Group)
 	for _, h := range g.onInstallationEvent[InstallationEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_installation_repositories.go
+++ b/githubevents/events_installation_repositories.go
@@ -103,8 +103,13 @@ func (g *EventHandler) handleInstallationRepositoriesEventAdded(ctx context.Cont
 		if _, ok := g.onInstallationRepositoriesEvent[action]; ok {
 			for _, h := range g.onInstallationRepositoriesEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -184,8 +189,13 @@ func (g *EventHandler) handleInstallationRepositoriesEventRemoved(ctx context.Co
 		if _, ok := g.onInstallationRepositoriesEvent[action]; ok {
 			for _, h := range g.onInstallationRepositoriesEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -256,8 +266,13 @@ func (g *EventHandler) handleInstallationRepositoriesEventAny(ctx context.Contex
 	eg := new(errgroup.Group)
 	for _, h := range g.onInstallationRepositoriesEvent[InstallationRepositoriesEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_installation_repositories_test.go
+++ b/githubevents/events_installation_repositories_test.go
@@ -117,6 +117,7 @@ func TestHandleInstallationRepositoriesEventAny(t *testing.T) {
 		eventName  string
 		event      *github.InstallationRepositoriesEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandleInstallationRepositoriesEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "installation_repositories",
+
+				event: &github.InstallationRepositoriesEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandleInstallationRepositoriesEventAny(t *testing.T) {
 			g.OnInstallationRepositoriesEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.InstallationRepositoriesEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandleInstallationRepositoriesEventAdded(t *testing.T) {
 		eventName  string
 		event      *github.InstallationRepositoriesEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandleInstallationRepositoriesEventAdded(t *testing.T) {
 				eventName:  "installation_repositories",
 				event:      &github.InstallationRepositoriesEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "installation_repositories",
+				event:      &github.InstallationRepositoriesEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandleInstallationRepositoriesEventAdded(t *testing.T) {
 			g.OnInstallationRepositoriesEventAdded(func(ctx context.Context, deliveryID string, eventName string, event *github.InstallationRepositoriesEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandleInstallationRepositoriesEventRemoved(t *testing.T) {
 		eventName  string
 		event      *github.InstallationRepositoriesEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandleInstallationRepositoriesEventRemoved(t *testing.T) {
 				eventName:  "installation_repositories",
 				event:      &github.InstallationRepositoriesEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "installation_repositories",
+				event:      &github.InstallationRepositoriesEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandleInstallationRepositoriesEventRemoved(t *testing.T) {
 			g.OnInstallationRepositoriesEventRemoved(func(ctx context.Context, deliveryID string, eventName string, event *github.InstallationRepositoriesEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_installation_test.go
+++ b/githubevents/events_installation_test.go
@@ -117,6 +117,7 @@ func TestHandleInstallationEventAny(t *testing.T) {
 		eventName  string
 		event      *github.InstallationEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandleInstallationEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "installation",
+
+				event: &github.InstallationEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandleInstallationEventAny(t *testing.T) {
 			g.OnInstallationEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.InstallationEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandleInstallationEventCreated(t *testing.T) {
 		eventName  string
 		event      *github.InstallationEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandleInstallationEventCreated(t *testing.T) {
 				eventName:  "installation",
 				event:      &github.InstallationEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "installation",
+				event:      &github.InstallationEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandleInstallationEventCreated(t *testing.T) {
 			g.OnInstallationEventCreated(func(ctx context.Context, deliveryID string, eventName string, event *github.InstallationEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandleInstallationEventDeleted(t *testing.T) {
 		eventName  string
 		event      *github.InstallationEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandleInstallationEventDeleted(t *testing.T) {
 				eventName:  "installation",
 				event:      &github.InstallationEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "installation",
+				event:      &github.InstallationEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandleInstallationEventDeleted(t *testing.T) {
 			g.OnInstallationEventDeleted(func(ctx context.Context, deliveryID string, eventName string, event *github.InstallationEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -652,6 +699,7 @@ func TestHandleInstallationEventEventSuspend(t *testing.T) {
 		eventName  string
 		event      *github.InstallationEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -675,6 +723,17 @@ func TestHandleInstallationEventEventSuspend(t *testing.T) {
 				eventName:  "installation",
 				event:      &github.InstallationEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "installation",
+				event:      &github.InstallationEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -725,6 +784,9 @@ func TestHandleInstallationEventEventSuspend(t *testing.T) {
 			g.OnInstallationEventEventSuspend(func(ctx context.Context, deliveryID string, eventName string, event *github.InstallationEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -839,6 +901,7 @@ func TestHandleInstallationEventEventUnsuspend(t *testing.T) {
 		eventName  string
 		event      *github.InstallationEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -862,6 +925,17 @@ func TestHandleInstallationEventEventUnsuspend(t *testing.T) {
 				eventName:  "installation",
 				event:      &github.InstallationEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "installation",
+				event:      &github.InstallationEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -912,6 +986,9 @@ func TestHandleInstallationEventEventUnsuspend(t *testing.T) {
 			g.OnInstallationEventEventUnsuspend(func(ctx context.Context, deliveryID string, eventName string, event *github.InstallationEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1026,6 +1103,7 @@ func TestHandleInstallationEventNewPermissionsAccepted(t *testing.T) {
 		eventName  string
 		event      *github.InstallationEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1049,6 +1127,17 @@ func TestHandleInstallationEventNewPermissionsAccepted(t *testing.T) {
 				eventName:  "installation",
 				event:      &github.InstallationEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "installation",
+				event:      &github.InstallationEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1099,6 +1188,9 @@ func TestHandleInstallationEventNewPermissionsAccepted(t *testing.T) {
 			g.OnInstallationEventNewPermissionsAccepted(func(ctx context.Context, deliveryID string, eventName string, event *github.InstallationEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_issue_comment.go
+++ b/githubevents/events_issue_comment.go
@@ -107,8 +107,13 @@ func (g *EventHandler) handleIssueCommentCreated(ctx context.Context, deliveryID
 		if _, ok := g.onIssueCommentEvent[action]; ok {
 			for _, h := range g.onIssueCommentEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -188,8 +193,13 @@ func (g *EventHandler) handleIssueCommentEdited(ctx context.Context, deliveryID 
 		if _, ok := g.onIssueCommentEvent[action]; ok {
 			for _, h := range g.onIssueCommentEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -269,8 +279,13 @@ func (g *EventHandler) handleIssueCommentDeleted(ctx context.Context, deliveryID
 		if _, ok := g.onIssueCommentEvent[action]; ok {
 			for _, h := range g.onIssueCommentEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -341,8 +356,13 @@ func (g *EventHandler) handleIssueCommentEventAny(ctx context.Context, deliveryI
 	eg := new(errgroup.Group)
 	for _, h := range g.onIssueCommentEvent[IssueCommentEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_issue_comment_test.go
+++ b/githubevents/events_issue_comment_test.go
@@ -117,6 +117,7 @@ func TestHandleIssueCommentEventAny(t *testing.T) {
 		eventName  string
 		event      *github.IssueCommentEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandleIssueCommentEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "issue_comment",
+
+				event: &github.IssueCommentEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandleIssueCommentEventAny(t *testing.T) {
 			g.OnIssueCommentEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.IssueCommentEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandleIssueCommentCreated(t *testing.T) {
 		eventName  string
 		event      *github.IssueCommentEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandleIssueCommentCreated(t *testing.T) {
 				eventName:  "issue_comment",
 				event:      &github.IssueCommentEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "issue_comment",
+				event:      &github.IssueCommentEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandleIssueCommentCreated(t *testing.T) {
 			g.OnIssueCommentCreated(func(ctx context.Context, deliveryID string, eventName string, event *github.IssueCommentEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandleIssueCommentEdited(t *testing.T) {
 		eventName  string
 		event      *github.IssueCommentEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandleIssueCommentEdited(t *testing.T) {
 				eventName:  "issue_comment",
 				event:      &github.IssueCommentEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "issue_comment",
+				event:      &github.IssueCommentEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandleIssueCommentEdited(t *testing.T) {
 			g.OnIssueCommentEdited(func(ctx context.Context, deliveryID string, eventName string, event *github.IssueCommentEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -652,6 +699,7 @@ func TestHandleIssueCommentDeleted(t *testing.T) {
 		eventName  string
 		event      *github.IssueCommentEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -675,6 +723,17 @@ func TestHandleIssueCommentDeleted(t *testing.T) {
 				eventName:  "issue_comment",
 				event:      &github.IssueCommentEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "issue_comment",
+				event:      &github.IssueCommentEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -725,6 +784,9 @@ func TestHandleIssueCommentDeleted(t *testing.T) {
 			g.OnIssueCommentDeleted(func(ctx context.Context, deliveryID string, eventName string, event *github.IssueCommentEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_issues.go
+++ b/githubevents/events_issues.go
@@ -159,8 +159,13 @@ func (g *EventHandler) handleIssuesEventOpened(ctx context.Context, deliveryID s
 		if _, ok := g.onIssuesEvent[action]; ok {
 			for _, h := range g.onIssuesEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -240,8 +245,13 @@ func (g *EventHandler) handleIssuesEventEdited(ctx context.Context, deliveryID s
 		if _, ok := g.onIssuesEvent[action]; ok {
 			for _, h := range g.onIssuesEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -321,8 +331,13 @@ func (g *EventHandler) handleIssuesEventDeleted(ctx context.Context, deliveryID 
 		if _, ok := g.onIssuesEvent[action]; ok {
 			for _, h := range g.onIssuesEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -402,8 +417,13 @@ func (g *EventHandler) handleIssuesEventPinned(ctx context.Context, deliveryID s
 		if _, ok := g.onIssuesEvent[action]; ok {
 			for _, h := range g.onIssuesEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -483,8 +503,13 @@ func (g *EventHandler) handleIssuesEventUnpinned(ctx context.Context, deliveryID
 		if _, ok := g.onIssuesEvent[action]; ok {
 			for _, h := range g.onIssuesEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -564,8 +589,13 @@ func (g *EventHandler) handleIssuesEventClosed(ctx context.Context, deliveryID s
 		if _, ok := g.onIssuesEvent[action]; ok {
 			for _, h := range g.onIssuesEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -645,8 +675,13 @@ func (g *EventHandler) handleIssuesEventReopened(ctx context.Context, deliveryID
 		if _, ok := g.onIssuesEvent[action]; ok {
 			for _, h := range g.onIssuesEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -726,8 +761,13 @@ func (g *EventHandler) handleIssuesEventAssigned(ctx context.Context, deliveryID
 		if _, ok := g.onIssuesEvent[action]; ok {
 			for _, h := range g.onIssuesEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -807,8 +847,13 @@ func (g *EventHandler) handleIssuesEventUnassigned(ctx context.Context, delivery
 		if _, ok := g.onIssuesEvent[action]; ok {
 			for _, h := range g.onIssuesEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -888,8 +933,13 @@ func (g *EventHandler) handleIssuesEventLabeled(ctx context.Context, deliveryID 
 		if _, ok := g.onIssuesEvent[action]; ok {
 			for _, h := range g.onIssuesEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -969,8 +1019,13 @@ func (g *EventHandler) handleIssuesEventUnlabeled(ctx context.Context, deliveryI
 		if _, ok := g.onIssuesEvent[action]; ok {
 			for _, h := range g.onIssuesEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -1050,8 +1105,13 @@ func (g *EventHandler) handleIssuesEventLocked(ctx context.Context, deliveryID s
 		if _, ok := g.onIssuesEvent[action]; ok {
 			for _, h := range g.onIssuesEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -1131,8 +1191,13 @@ func (g *EventHandler) handleIssuesEventUnlocked(ctx context.Context, deliveryID
 		if _, ok := g.onIssuesEvent[action]; ok {
 			for _, h := range g.onIssuesEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -1212,8 +1277,13 @@ func (g *EventHandler) handleIssuesEventTransferred(ctx context.Context, deliver
 		if _, ok := g.onIssuesEvent[action]; ok {
 			for _, h := range g.onIssuesEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -1293,8 +1363,13 @@ func (g *EventHandler) handleIssuesEventMilestoned(ctx context.Context, delivery
 		if _, ok := g.onIssuesEvent[action]; ok {
 			for _, h := range g.onIssuesEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -1374,8 +1449,13 @@ func (g *EventHandler) handleIssuesEventDeMilestoned(ctx context.Context, delive
 		if _, ok := g.onIssuesEvent[action]; ok {
 			for _, h := range g.onIssuesEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -1446,8 +1526,13 @@ func (g *EventHandler) handleIssuesEventAny(ctx context.Context, deliveryID stri
 	eg := new(errgroup.Group)
 	for _, h := range g.onIssuesEvent[IssuesEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_issues_test.go
+++ b/githubevents/events_issues_test.go
@@ -117,6 +117,7 @@ func TestHandleIssuesEventAny(t *testing.T) {
 		eventName  string
 		event      *github.IssuesEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandleIssuesEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "issues",
+
+				event: &github.IssuesEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandleIssuesEventAny(t *testing.T) {
 			g.OnIssuesEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.IssuesEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandleIssuesEventOpened(t *testing.T) {
 		eventName  string
 		event      *github.IssuesEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandleIssuesEventOpened(t *testing.T) {
 				eventName:  "issues",
 				event:      &github.IssuesEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "issues",
+				event:      &github.IssuesEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandleIssuesEventOpened(t *testing.T) {
 			g.OnIssuesEventOpened(func(ctx context.Context, deliveryID string, eventName string, event *github.IssuesEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandleIssuesEventEdited(t *testing.T) {
 		eventName  string
 		event      *github.IssuesEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandleIssuesEventEdited(t *testing.T) {
 				eventName:  "issues",
 				event:      &github.IssuesEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "issues",
+				event:      &github.IssuesEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandleIssuesEventEdited(t *testing.T) {
 			g.OnIssuesEventEdited(func(ctx context.Context, deliveryID string, eventName string, event *github.IssuesEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -652,6 +699,7 @@ func TestHandleIssuesEventDeleted(t *testing.T) {
 		eventName  string
 		event      *github.IssuesEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -675,6 +723,17 @@ func TestHandleIssuesEventDeleted(t *testing.T) {
 				eventName:  "issues",
 				event:      &github.IssuesEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "issues",
+				event:      &github.IssuesEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -725,6 +784,9 @@ func TestHandleIssuesEventDeleted(t *testing.T) {
 			g.OnIssuesEventDeleted(func(ctx context.Context, deliveryID string, eventName string, event *github.IssuesEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -839,6 +901,7 @@ func TestHandleIssuesEventPinned(t *testing.T) {
 		eventName  string
 		event      *github.IssuesEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -862,6 +925,17 @@ func TestHandleIssuesEventPinned(t *testing.T) {
 				eventName:  "issues",
 				event:      &github.IssuesEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "issues",
+				event:      &github.IssuesEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -912,6 +986,9 @@ func TestHandleIssuesEventPinned(t *testing.T) {
 			g.OnIssuesEventPinned(func(ctx context.Context, deliveryID string, eventName string, event *github.IssuesEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1026,6 +1103,7 @@ func TestHandleIssuesEventUnpinned(t *testing.T) {
 		eventName  string
 		event      *github.IssuesEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1049,6 +1127,17 @@ func TestHandleIssuesEventUnpinned(t *testing.T) {
 				eventName:  "issues",
 				event:      &github.IssuesEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "issues",
+				event:      &github.IssuesEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1099,6 +1188,9 @@ func TestHandleIssuesEventUnpinned(t *testing.T) {
 			g.OnIssuesEventUnpinned(func(ctx context.Context, deliveryID string, eventName string, event *github.IssuesEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1213,6 +1305,7 @@ func TestHandleIssuesEventClosed(t *testing.T) {
 		eventName  string
 		event      *github.IssuesEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1236,6 +1329,17 @@ func TestHandleIssuesEventClosed(t *testing.T) {
 				eventName:  "issues",
 				event:      &github.IssuesEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "issues",
+				event:      &github.IssuesEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1286,6 +1390,9 @@ func TestHandleIssuesEventClosed(t *testing.T) {
 			g.OnIssuesEventClosed(func(ctx context.Context, deliveryID string, eventName string, event *github.IssuesEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1400,6 +1507,7 @@ func TestHandleIssuesEventReopened(t *testing.T) {
 		eventName  string
 		event      *github.IssuesEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1423,6 +1531,17 @@ func TestHandleIssuesEventReopened(t *testing.T) {
 				eventName:  "issues",
 				event:      &github.IssuesEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "issues",
+				event:      &github.IssuesEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1473,6 +1592,9 @@ func TestHandleIssuesEventReopened(t *testing.T) {
 			g.OnIssuesEventReopened(func(ctx context.Context, deliveryID string, eventName string, event *github.IssuesEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1587,6 +1709,7 @@ func TestHandleIssuesEventAssigned(t *testing.T) {
 		eventName  string
 		event      *github.IssuesEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1610,6 +1733,17 @@ func TestHandleIssuesEventAssigned(t *testing.T) {
 				eventName:  "issues",
 				event:      &github.IssuesEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "issues",
+				event:      &github.IssuesEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1660,6 +1794,9 @@ func TestHandleIssuesEventAssigned(t *testing.T) {
 			g.OnIssuesEventAssigned(func(ctx context.Context, deliveryID string, eventName string, event *github.IssuesEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1774,6 +1911,7 @@ func TestHandleIssuesEventUnassigned(t *testing.T) {
 		eventName  string
 		event      *github.IssuesEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1797,6 +1935,17 @@ func TestHandleIssuesEventUnassigned(t *testing.T) {
 				eventName:  "issues",
 				event:      &github.IssuesEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "issues",
+				event:      &github.IssuesEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1847,6 +1996,9 @@ func TestHandleIssuesEventUnassigned(t *testing.T) {
 			g.OnIssuesEventUnassigned(func(ctx context.Context, deliveryID string, eventName string, event *github.IssuesEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1961,6 +2113,7 @@ func TestHandleIssuesEventLabeled(t *testing.T) {
 		eventName  string
 		event      *github.IssuesEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1984,6 +2137,17 @@ func TestHandleIssuesEventLabeled(t *testing.T) {
 				eventName:  "issues",
 				event:      &github.IssuesEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "issues",
+				event:      &github.IssuesEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -2034,6 +2198,9 @@ func TestHandleIssuesEventLabeled(t *testing.T) {
 			g.OnIssuesEventLabeled(func(ctx context.Context, deliveryID string, eventName string, event *github.IssuesEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -2148,6 +2315,7 @@ func TestHandleIssuesEventUnlabeled(t *testing.T) {
 		eventName  string
 		event      *github.IssuesEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -2171,6 +2339,17 @@ func TestHandleIssuesEventUnlabeled(t *testing.T) {
 				eventName:  "issues",
 				event:      &github.IssuesEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "issues",
+				event:      &github.IssuesEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -2221,6 +2400,9 @@ func TestHandleIssuesEventUnlabeled(t *testing.T) {
 			g.OnIssuesEventUnlabeled(func(ctx context.Context, deliveryID string, eventName string, event *github.IssuesEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -2335,6 +2517,7 @@ func TestHandleIssuesEventLocked(t *testing.T) {
 		eventName  string
 		event      *github.IssuesEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -2358,6 +2541,17 @@ func TestHandleIssuesEventLocked(t *testing.T) {
 				eventName:  "issues",
 				event:      &github.IssuesEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "issues",
+				event:      &github.IssuesEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -2408,6 +2602,9 @@ func TestHandleIssuesEventLocked(t *testing.T) {
 			g.OnIssuesEventLocked(func(ctx context.Context, deliveryID string, eventName string, event *github.IssuesEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -2522,6 +2719,7 @@ func TestHandleIssuesEventUnlocked(t *testing.T) {
 		eventName  string
 		event      *github.IssuesEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -2545,6 +2743,17 @@ func TestHandleIssuesEventUnlocked(t *testing.T) {
 				eventName:  "issues",
 				event:      &github.IssuesEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "issues",
+				event:      &github.IssuesEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -2595,6 +2804,9 @@ func TestHandleIssuesEventUnlocked(t *testing.T) {
 			g.OnIssuesEventUnlocked(func(ctx context.Context, deliveryID string, eventName string, event *github.IssuesEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -2709,6 +2921,7 @@ func TestHandleIssuesEventTransferred(t *testing.T) {
 		eventName  string
 		event      *github.IssuesEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -2732,6 +2945,17 @@ func TestHandleIssuesEventTransferred(t *testing.T) {
 				eventName:  "issues",
 				event:      &github.IssuesEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "issues",
+				event:      &github.IssuesEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -2782,6 +3006,9 @@ func TestHandleIssuesEventTransferred(t *testing.T) {
 			g.OnIssuesEventTransferred(func(ctx context.Context, deliveryID string, eventName string, event *github.IssuesEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -2896,6 +3123,7 @@ func TestHandleIssuesEventMilestoned(t *testing.T) {
 		eventName  string
 		event      *github.IssuesEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -2919,6 +3147,17 @@ func TestHandleIssuesEventMilestoned(t *testing.T) {
 				eventName:  "issues",
 				event:      &github.IssuesEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "issues",
+				event:      &github.IssuesEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -2969,6 +3208,9 @@ func TestHandleIssuesEventMilestoned(t *testing.T) {
 			g.OnIssuesEventMilestoned(func(ctx context.Context, deliveryID string, eventName string, event *github.IssuesEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -3083,6 +3325,7 @@ func TestHandleIssuesEventDeMilestoned(t *testing.T) {
 		eventName  string
 		event      *github.IssuesEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -3106,6 +3349,17 @@ func TestHandleIssuesEventDeMilestoned(t *testing.T) {
 				eventName:  "issues",
 				event:      &github.IssuesEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "issues",
+				event:      &github.IssuesEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -3156,6 +3410,9 @@ func TestHandleIssuesEventDeMilestoned(t *testing.T) {
 			g.OnIssuesEventDeMilestoned(func(ctx context.Context, deliveryID string, eventName string, event *github.IssuesEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_label.go
+++ b/githubevents/events_label.go
@@ -107,8 +107,13 @@ func (g *EventHandler) handleLabelEventCreated(ctx context.Context, deliveryID s
 		if _, ok := g.onLabelEvent[action]; ok {
 			for _, h := range g.onLabelEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -188,8 +193,13 @@ func (g *EventHandler) handleLabelEventEdited(ctx context.Context, deliveryID st
 		if _, ok := g.onLabelEvent[action]; ok {
 			for _, h := range g.onLabelEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -269,8 +279,13 @@ func (g *EventHandler) handleLabelEventDeleted(ctx context.Context, deliveryID s
 		if _, ok := g.onLabelEvent[action]; ok {
 			for _, h := range g.onLabelEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -341,8 +356,13 @@ func (g *EventHandler) handleLabelEventAny(ctx context.Context, deliveryID strin
 	eg := new(errgroup.Group)
 	for _, h := range g.onLabelEvent[LabelEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_label_test.go
+++ b/githubevents/events_label_test.go
@@ -117,6 +117,7 @@ func TestHandleLabelEventAny(t *testing.T) {
 		eventName  string
 		event      *github.LabelEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandleLabelEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "label",
+
+				event: &github.LabelEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandleLabelEventAny(t *testing.T) {
 			g.OnLabelEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.LabelEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandleLabelEventCreated(t *testing.T) {
 		eventName  string
 		event      *github.LabelEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandleLabelEventCreated(t *testing.T) {
 				eventName:  "label",
 				event:      &github.LabelEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "label",
+				event:      &github.LabelEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandleLabelEventCreated(t *testing.T) {
 			g.OnLabelEventCreated(func(ctx context.Context, deliveryID string, eventName string, event *github.LabelEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandleLabelEventEdited(t *testing.T) {
 		eventName  string
 		event      *github.LabelEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandleLabelEventEdited(t *testing.T) {
 				eventName:  "label",
 				event:      &github.LabelEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "label",
+				event:      &github.LabelEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandleLabelEventEdited(t *testing.T) {
 			g.OnLabelEventEdited(func(ctx context.Context, deliveryID string, eventName string, event *github.LabelEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -652,6 +699,7 @@ func TestHandleLabelEventDeleted(t *testing.T) {
 		eventName  string
 		event      *github.LabelEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -675,6 +723,17 @@ func TestHandleLabelEventDeleted(t *testing.T) {
 				eventName:  "label",
 				event:      &github.LabelEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "label",
+				event:      &github.LabelEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -725,6 +784,9 @@ func TestHandleLabelEventDeleted(t *testing.T) {
 			g.OnLabelEventDeleted(func(ctx context.Context, deliveryID string, eventName string, event *github.LabelEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_marketplace_purchase.go
+++ b/githubevents/events_marketplace_purchase.go
@@ -115,8 +115,13 @@ func (g *EventHandler) handleMarketplacePurchaseEventPurchased(ctx context.Conte
 		if _, ok := g.onMarketplacePurchaseEvent[action]; ok {
 			for _, h := range g.onMarketplacePurchaseEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -196,8 +201,13 @@ func (g *EventHandler) handleMarketplacePurchaseEventPendingChange(ctx context.C
 		if _, ok := g.onMarketplacePurchaseEvent[action]; ok {
 			for _, h := range g.onMarketplacePurchaseEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -277,8 +287,13 @@ func (g *EventHandler) handleMarketplacePurchaseEventPendingChangeCancelled(ctx 
 		if _, ok := g.onMarketplacePurchaseEvent[action]; ok {
 			for _, h := range g.onMarketplacePurchaseEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -358,8 +373,13 @@ func (g *EventHandler) handleMarketplacePurchaseEventChanged(ctx context.Context
 		if _, ok := g.onMarketplacePurchaseEvent[action]; ok {
 			for _, h := range g.onMarketplacePurchaseEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -439,8 +459,13 @@ func (g *EventHandler) handleMarketplacePurchaseEventCancelled(ctx context.Conte
 		if _, ok := g.onMarketplacePurchaseEvent[action]; ok {
 			for _, h := range g.onMarketplacePurchaseEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -511,8 +536,13 @@ func (g *EventHandler) handleMarketplacePurchaseEventAny(ctx context.Context, de
 	eg := new(errgroup.Group)
 	for _, h := range g.onMarketplacePurchaseEvent[MarketplacePurchaseEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_marketplace_purchase_test.go
+++ b/githubevents/events_marketplace_purchase_test.go
@@ -117,6 +117,7 @@ func TestHandleMarketplacePurchaseEventAny(t *testing.T) {
 		eventName  string
 		event      *github.MarketplacePurchaseEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandleMarketplacePurchaseEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "marketplace_purchase",
+
+				event: &github.MarketplacePurchaseEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandleMarketplacePurchaseEventAny(t *testing.T) {
 			g.OnMarketplacePurchaseEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.MarketplacePurchaseEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandleMarketplacePurchaseEventPurchased(t *testing.T) {
 		eventName  string
 		event      *github.MarketplacePurchaseEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandleMarketplacePurchaseEventPurchased(t *testing.T) {
 				eventName:  "marketplace_purchase",
 				event:      &github.MarketplacePurchaseEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "marketplace_purchase",
+				event:      &github.MarketplacePurchaseEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandleMarketplacePurchaseEventPurchased(t *testing.T) {
 			g.OnMarketplacePurchaseEventPurchased(func(ctx context.Context, deliveryID string, eventName string, event *github.MarketplacePurchaseEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandleMarketplacePurchaseEventPendingChange(t *testing.T) {
 		eventName  string
 		event      *github.MarketplacePurchaseEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandleMarketplacePurchaseEventPendingChange(t *testing.T) {
 				eventName:  "marketplace_purchase",
 				event:      &github.MarketplacePurchaseEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "marketplace_purchase",
+				event:      &github.MarketplacePurchaseEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandleMarketplacePurchaseEventPendingChange(t *testing.T) {
 			g.OnMarketplacePurchaseEventPendingChange(func(ctx context.Context, deliveryID string, eventName string, event *github.MarketplacePurchaseEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -652,6 +699,7 @@ func TestHandleMarketplacePurchaseEventPendingChangeCancelled(t *testing.T) {
 		eventName  string
 		event      *github.MarketplacePurchaseEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -675,6 +723,17 @@ func TestHandleMarketplacePurchaseEventPendingChangeCancelled(t *testing.T) {
 				eventName:  "marketplace_purchase",
 				event:      &github.MarketplacePurchaseEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "marketplace_purchase",
+				event:      &github.MarketplacePurchaseEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -725,6 +784,9 @@ func TestHandleMarketplacePurchaseEventPendingChangeCancelled(t *testing.T) {
 			g.OnMarketplacePurchaseEventPendingChangeCancelled(func(ctx context.Context, deliveryID string, eventName string, event *github.MarketplacePurchaseEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -839,6 +901,7 @@ func TestHandleMarketplacePurchaseEventChanged(t *testing.T) {
 		eventName  string
 		event      *github.MarketplacePurchaseEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -862,6 +925,17 @@ func TestHandleMarketplacePurchaseEventChanged(t *testing.T) {
 				eventName:  "marketplace_purchase",
 				event:      &github.MarketplacePurchaseEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "marketplace_purchase",
+				event:      &github.MarketplacePurchaseEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -912,6 +986,9 @@ func TestHandleMarketplacePurchaseEventChanged(t *testing.T) {
 			g.OnMarketplacePurchaseEventChanged(func(ctx context.Context, deliveryID string, eventName string, event *github.MarketplacePurchaseEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1026,6 +1103,7 @@ func TestHandleMarketplacePurchaseEventCancelled(t *testing.T) {
 		eventName  string
 		event      *github.MarketplacePurchaseEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1049,6 +1127,17 @@ func TestHandleMarketplacePurchaseEventCancelled(t *testing.T) {
 				eventName:  "marketplace_purchase",
 				event:      &github.MarketplacePurchaseEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "marketplace_purchase",
+				event:      &github.MarketplacePurchaseEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1099,6 +1188,9 @@ func TestHandleMarketplacePurchaseEventCancelled(t *testing.T) {
 			g.OnMarketplacePurchaseEventCancelled(func(ctx context.Context, deliveryID string, eventName string, event *github.MarketplacePurchaseEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_member.go
+++ b/githubevents/events_member.go
@@ -107,8 +107,13 @@ func (g *EventHandler) handleMemberEventAdded(ctx context.Context, deliveryID st
 		if _, ok := g.onMemberEvent[action]; ok {
 			for _, h := range g.onMemberEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -188,8 +193,13 @@ func (g *EventHandler) handleMemberEventRemoved(ctx context.Context, deliveryID 
 		if _, ok := g.onMemberEvent[action]; ok {
 			for _, h := range g.onMemberEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -269,8 +279,13 @@ func (g *EventHandler) handleMemberEventEdited(ctx context.Context, deliveryID s
 		if _, ok := g.onMemberEvent[action]; ok {
 			for _, h := range g.onMemberEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -341,8 +356,13 @@ func (g *EventHandler) handleMemberEventAny(ctx context.Context, deliveryID stri
 	eg := new(errgroup.Group)
 	for _, h := range g.onMemberEvent[MemberEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_member_test.go
+++ b/githubevents/events_member_test.go
@@ -117,6 +117,7 @@ func TestHandleMemberEventAny(t *testing.T) {
 		eventName  string
 		event      *github.MemberEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandleMemberEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "member",
+
+				event: &github.MemberEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandleMemberEventAny(t *testing.T) {
 			g.OnMemberEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.MemberEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandleMemberEventAdded(t *testing.T) {
 		eventName  string
 		event      *github.MemberEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandleMemberEventAdded(t *testing.T) {
 				eventName:  "member",
 				event:      &github.MemberEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "member",
+				event:      &github.MemberEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandleMemberEventAdded(t *testing.T) {
 			g.OnMemberEventAdded(func(ctx context.Context, deliveryID string, eventName string, event *github.MemberEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandleMemberEventRemoved(t *testing.T) {
 		eventName  string
 		event      *github.MemberEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandleMemberEventRemoved(t *testing.T) {
 				eventName:  "member",
 				event:      &github.MemberEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "member",
+				event:      &github.MemberEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandleMemberEventRemoved(t *testing.T) {
 			g.OnMemberEventRemoved(func(ctx context.Context, deliveryID string, eventName string, event *github.MemberEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -652,6 +699,7 @@ func TestHandleMemberEventEdited(t *testing.T) {
 		eventName  string
 		event      *github.MemberEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -675,6 +723,17 @@ func TestHandleMemberEventEdited(t *testing.T) {
 				eventName:  "member",
 				event:      &github.MemberEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "member",
+				event:      &github.MemberEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -725,6 +784,9 @@ func TestHandleMemberEventEdited(t *testing.T) {
 			g.OnMemberEventEdited(func(ctx context.Context, deliveryID string, eventName string, event *github.MemberEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_membership.go
+++ b/githubevents/events_membership.go
@@ -103,8 +103,13 @@ func (g *EventHandler) handleMembershipEventAdded(ctx context.Context, deliveryI
 		if _, ok := g.onMembershipEvent[action]; ok {
 			for _, h := range g.onMembershipEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -184,8 +189,13 @@ func (g *EventHandler) handleMembershipEventRemoved(ctx context.Context, deliver
 		if _, ok := g.onMembershipEvent[action]; ok {
 			for _, h := range g.onMembershipEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -256,8 +266,13 @@ func (g *EventHandler) handleMembershipEventAny(ctx context.Context, deliveryID 
 	eg := new(errgroup.Group)
 	for _, h := range g.onMembershipEvent[MembershipEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_membership_test.go
+++ b/githubevents/events_membership_test.go
@@ -117,6 +117,7 @@ func TestHandleMembershipEventAny(t *testing.T) {
 		eventName  string
 		event      *github.MembershipEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandleMembershipEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "membership",
+
+				event: &github.MembershipEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandleMembershipEventAny(t *testing.T) {
 			g.OnMembershipEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.MembershipEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandleMembershipEventAdded(t *testing.T) {
 		eventName  string
 		event      *github.MembershipEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandleMembershipEventAdded(t *testing.T) {
 				eventName:  "membership",
 				event:      &github.MembershipEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "membership",
+				event:      &github.MembershipEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandleMembershipEventAdded(t *testing.T) {
 			g.OnMembershipEventAdded(func(ctx context.Context, deliveryID string, eventName string, event *github.MembershipEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandleMembershipEventRemoved(t *testing.T) {
 		eventName  string
 		event      *github.MembershipEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandleMembershipEventRemoved(t *testing.T) {
 				eventName:  "membership",
 				event:      &github.MembershipEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "membership",
+				event:      &github.MembershipEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandleMembershipEventRemoved(t *testing.T) {
 			g.OnMembershipEventRemoved(func(ctx context.Context, deliveryID string, eventName string, event *github.MembershipEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_merge_group_event.go
+++ b/githubevents/events_merge_group_event.go
@@ -103,8 +103,13 @@ func (g *EventHandler) handleMergeGroupEventChecksRequested(ctx context.Context,
 		if _, ok := g.onMergeGroupEvent[action]; ok {
 			for _, h := range g.onMergeGroupEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -184,8 +189,13 @@ func (g *EventHandler) handleMergeGroupEventDestroyed(ctx context.Context, deliv
 		if _, ok := g.onMergeGroupEvent[action]; ok {
 			for _, h := range g.onMergeGroupEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -256,8 +266,13 @@ func (g *EventHandler) handleMergeGroupEventAny(ctx context.Context, deliveryID 
 	eg := new(errgroup.Group)
 	for _, h := range g.onMergeGroupEvent[MergeGroupEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_merge_group_event_test.go
+++ b/githubevents/events_merge_group_event_test.go
@@ -117,6 +117,7 @@ func TestHandleMergeGroupEventAny(t *testing.T) {
 		eventName  string
 		event      *github.MergeGroupEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandleMergeGroupEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "merge_group_event",
+
+				event: &github.MergeGroupEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandleMergeGroupEventAny(t *testing.T) {
 			g.OnMergeGroupEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.MergeGroupEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandleMergeGroupEventChecksRequested(t *testing.T) {
 		eventName  string
 		event      *github.MergeGroupEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandleMergeGroupEventChecksRequested(t *testing.T) {
 				eventName:  "merge_group_event",
 				event:      &github.MergeGroupEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "merge_group_event",
+				event:      &github.MergeGroupEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandleMergeGroupEventChecksRequested(t *testing.T) {
 			g.OnMergeGroupEventChecksRequested(func(ctx context.Context, deliveryID string, eventName string, event *github.MergeGroupEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandleMergeGroupEventDestroyed(t *testing.T) {
 		eventName  string
 		event      *github.MergeGroupEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandleMergeGroupEventDestroyed(t *testing.T) {
 				eventName:  "merge_group_event",
 				event:      &github.MergeGroupEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "merge_group_event",
+				event:      &github.MergeGroupEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandleMergeGroupEventDestroyed(t *testing.T) {
 			g.OnMergeGroupEventDestroyed(func(ctx context.Context, deliveryID string, eventName string, event *github.MergeGroupEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_meta.go
+++ b/githubevents/events_meta.go
@@ -86,8 +86,13 @@ func (g *EventHandler) handleMetaEventAny(ctx context.Context, deliveryID string
 	eg := new(errgroup.Group)
 	for _, h := range g.onMetaEvent[MetaEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_meta_test.go
+++ b/githubevents/events_meta_test.go
@@ -115,6 +115,7 @@ func TestHandleMetaEventAny(t *testing.T) {
 		eventName  string
 		event      *github.MetaEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -146,6 +147,19 @@ func TestHandleMetaEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "meta",
+
+				event: &github.MetaEvent{},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -162,6 +176,9 @@ func TestHandleMetaEventAny(t *testing.T) {
 			g.OnMetaEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.MetaEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_milestone.go
+++ b/githubevents/events_milestone.go
@@ -115,8 +115,13 @@ func (g *EventHandler) handleMilestoneEventCreated(ctx context.Context, delivery
 		if _, ok := g.onMilestoneEvent[action]; ok {
 			for _, h := range g.onMilestoneEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -196,8 +201,13 @@ func (g *EventHandler) handleMilestoneEventClosed(ctx context.Context, deliveryI
 		if _, ok := g.onMilestoneEvent[action]; ok {
 			for _, h := range g.onMilestoneEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -277,8 +287,13 @@ func (g *EventHandler) handleMilestoneEventOpened(ctx context.Context, deliveryI
 		if _, ok := g.onMilestoneEvent[action]; ok {
 			for _, h := range g.onMilestoneEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -358,8 +373,13 @@ func (g *EventHandler) handleMilestoneEventEdited(ctx context.Context, deliveryI
 		if _, ok := g.onMilestoneEvent[action]; ok {
 			for _, h := range g.onMilestoneEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -439,8 +459,13 @@ func (g *EventHandler) handleMilestoneEventDeleted(ctx context.Context, delivery
 		if _, ok := g.onMilestoneEvent[action]; ok {
 			for _, h := range g.onMilestoneEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -511,8 +536,13 @@ func (g *EventHandler) handleMilestoneEventAny(ctx context.Context, deliveryID s
 	eg := new(errgroup.Group)
 	for _, h := range g.onMilestoneEvent[MilestoneEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_milestone_test.go
+++ b/githubevents/events_milestone_test.go
@@ -117,6 +117,7 @@ func TestHandleMilestoneEventAny(t *testing.T) {
 		eventName  string
 		event      *github.MilestoneEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandleMilestoneEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "milestone",
+
+				event: &github.MilestoneEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandleMilestoneEventAny(t *testing.T) {
 			g.OnMilestoneEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.MilestoneEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandleMilestoneEventCreated(t *testing.T) {
 		eventName  string
 		event      *github.MilestoneEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandleMilestoneEventCreated(t *testing.T) {
 				eventName:  "milestone",
 				event:      &github.MilestoneEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "milestone",
+				event:      &github.MilestoneEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandleMilestoneEventCreated(t *testing.T) {
 			g.OnMilestoneEventCreated(func(ctx context.Context, deliveryID string, eventName string, event *github.MilestoneEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandleMilestoneEventClosed(t *testing.T) {
 		eventName  string
 		event      *github.MilestoneEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandleMilestoneEventClosed(t *testing.T) {
 				eventName:  "milestone",
 				event:      &github.MilestoneEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "milestone",
+				event:      &github.MilestoneEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandleMilestoneEventClosed(t *testing.T) {
 			g.OnMilestoneEventClosed(func(ctx context.Context, deliveryID string, eventName string, event *github.MilestoneEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -652,6 +699,7 @@ func TestHandleMilestoneEventOpened(t *testing.T) {
 		eventName  string
 		event      *github.MilestoneEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -675,6 +723,17 @@ func TestHandleMilestoneEventOpened(t *testing.T) {
 				eventName:  "milestone",
 				event:      &github.MilestoneEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "milestone",
+				event:      &github.MilestoneEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -725,6 +784,9 @@ func TestHandleMilestoneEventOpened(t *testing.T) {
 			g.OnMilestoneEventOpened(func(ctx context.Context, deliveryID string, eventName string, event *github.MilestoneEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -839,6 +901,7 @@ func TestHandleMilestoneEventEdited(t *testing.T) {
 		eventName  string
 		event      *github.MilestoneEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -862,6 +925,17 @@ func TestHandleMilestoneEventEdited(t *testing.T) {
 				eventName:  "milestone",
 				event:      &github.MilestoneEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "milestone",
+				event:      &github.MilestoneEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -912,6 +986,9 @@ func TestHandleMilestoneEventEdited(t *testing.T) {
 			g.OnMilestoneEventEdited(func(ctx context.Context, deliveryID string, eventName string, event *github.MilestoneEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1026,6 +1103,7 @@ func TestHandleMilestoneEventDeleted(t *testing.T) {
 		eventName  string
 		event      *github.MilestoneEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1049,6 +1127,17 @@ func TestHandleMilestoneEventDeleted(t *testing.T) {
 				eventName:  "milestone",
 				event:      &github.MilestoneEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "milestone",
+				event:      &github.MilestoneEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1099,6 +1188,9 @@ func TestHandleMilestoneEventDeleted(t *testing.T) {
 			g.OnMilestoneEventDeleted(func(ctx context.Context, deliveryID string, eventName string, event *github.MilestoneEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_org_block.go
+++ b/githubevents/events_org_block.go
@@ -103,8 +103,13 @@ func (g *EventHandler) handleOrgBlockEventBlocked(ctx context.Context, deliveryI
 		if _, ok := g.onOrgBlockEvent[action]; ok {
 			for _, h := range g.onOrgBlockEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -184,8 +189,13 @@ func (g *EventHandler) handleOrgBlockEventUnblocked(ctx context.Context, deliver
 		if _, ok := g.onOrgBlockEvent[action]; ok {
 			for _, h := range g.onOrgBlockEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -256,8 +266,13 @@ func (g *EventHandler) handleOrgBlockEventAny(ctx context.Context, deliveryID st
 	eg := new(errgroup.Group)
 	for _, h := range g.onOrgBlockEvent[OrgBlockEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_org_block_test.go
+++ b/githubevents/events_org_block_test.go
@@ -117,6 +117,7 @@ func TestHandleOrgBlockEventAny(t *testing.T) {
 		eventName  string
 		event      *github.OrgBlockEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandleOrgBlockEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "org_block",
+
+				event: &github.OrgBlockEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandleOrgBlockEventAny(t *testing.T) {
 			g.OnOrgBlockEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.OrgBlockEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandleOrgBlockEventBlocked(t *testing.T) {
 		eventName  string
 		event      *github.OrgBlockEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandleOrgBlockEventBlocked(t *testing.T) {
 				eventName:  "org_block",
 				event:      &github.OrgBlockEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "org_block",
+				event:      &github.OrgBlockEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandleOrgBlockEventBlocked(t *testing.T) {
 			g.OnOrgBlockEventBlocked(func(ctx context.Context, deliveryID string, eventName string, event *github.OrgBlockEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandleOrgBlockEventUnblocked(t *testing.T) {
 		eventName  string
 		event      *github.OrgBlockEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandleOrgBlockEventUnblocked(t *testing.T) {
 				eventName:  "org_block",
 				event:      &github.OrgBlockEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "org_block",
+				event:      &github.OrgBlockEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandleOrgBlockEventUnblocked(t *testing.T) {
 			g.OnOrgBlockEventUnblocked(func(ctx context.Context, deliveryID string, eventName string, event *github.OrgBlockEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_organization.go
+++ b/githubevents/events_organization.go
@@ -115,8 +115,13 @@ func (g *EventHandler) handleOrganizationEventDeleted(ctx context.Context, deliv
 		if _, ok := g.onOrganizationEvent[action]; ok {
 			for _, h := range g.onOrganizationEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -196,8 +201,13 @@ func (g *EventHandler) handleOrganizationEventRenamed(ctx context.Context, deliv
 		if _, ok := g.onOrganizationEvent[action]; ok {
 			for _, h := range g.onOrganizationEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -277,8 +287,13 @@ func (g *EventHandler) handleOrganizationEventMemberAdded(ctx context.Context, d
 		if _, ok := g.onOrganizationEvent[action]; ok {
 			for _, h := range g.onOrganizationEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -358,8 +373,13 @@ func (g *EventHandler) handleOrganizationEventMemberRemoved(ctx context.Context,
 		if _, ok := g.onOrganizationEvent[action]; ok {
 			for _, h := range g.onOrganizationEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -439,8 +459,13 @@ func (g *EventHandler) handleOrganizationEventMemberInvited(ctx context.Context,
 		if _, ok := g.onOrganizationEvent[action]; ok {
 			for _, h := range g.onOrganizationEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -511,8 +536,13 @@ func (g *EventHandler) handleOrganizationEventAny(ctx context.Context, deliveryI
 	eg := new(errgroup.Group)
 	for _, h := range g.onOrganizationEvent[OrganizationEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_organization_test.go
+++ b/githubevents/events_organization_test.go
@@ -117,6 +117,7 @@ func TestHandleOrganizationEventAny(t *testing.T) {
 		eventName  string
 		event      *github.OrganizationEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandleOrganizationEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "organization",
+
+				event: &github.OrganizationEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandleOrganizationEventAny(t *testing.T) {
 			g.OnOrganizationEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.OrganizationEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandleOrganizationEventDeleted(t *testing.T) {
 		eventName  string
 		event      *github.OrganizationEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandleOrganizationEventDeleted(t *testing.T) {
 				eventName:  "organization",
 				event:      &github.OrganizationEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "organization",
+				event:      &github.OrganizationEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandleOrganizationEventDeleted(t *testing.T) {
 			g.OnOrganizationEventDeleted(func(ctx context.Context, deliveryID string, eventName string, event *github.OrganizationEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandleOrganizationEventRenamed(t *testing.T) {
 		eventName  string
 		event      *github.OrganizationEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandleOrganizationEventRenamed(t *testing.T) {
 				eventName:  "organization",
 				event:      &github.OrganizationEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "organization",
+				event:      &github.OrganizationEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandleOrganizationEventRenamed(t *testing.T) {
 			g.OnOrganizationEventRenamed(func(ctx context.Context, deliveryID string, eventName string, event *github.OrganizationEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -652,6 +699,7 @@ func TestHandleOrganizationEventMemberAdded(t *testing.T) {
 		eventName  string
 		event      *github.OrganizationEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -675,6 +723,17 @@ func TestHandleOrganizationEventMemberAdded(t *testing.T) {
 				eventName:  "organization",
 				event:      &github.OrganizationEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "organization",
+				event:      &github.OrganizationEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -725,6 +784,9 @@ func TestHandleOrganizationEventMemberAdded(t *testing.T) {
 			g.OnOrganizationEventMemberAdded(func(ctx context.Context, deliveryID string, eventName string, event *github.OrganizationEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -839,6 +901,7 @@ func TestHandleOrganizationEventMemberRemoved(t *testing.T) {
 		eventName  string
 		event      *github.OrganizationEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -862,6 +925,17 @@ func TestHandleOrganizationEventMemberRemoved(t *testing.T) {
 				eventName:  "organization",
 				event:      &github.OrganizationEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "organization",
+				event:      &github.OrganizationEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -912,6 +986,9 @@ func TestHandleOrganizationEventMemberRemoved(t *testing.T) {
 			g.OnOrganizationEventMemberRemoved(func(ctx context.Context, deliveryID string, eventName string, event *github.OrganizationEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1026,6 +1103,7 @@ func TestHandleOrganizationEventMemberInvited(t *testing.T) {
 		eventName  string
 		event      *github.OrganizationEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1049,6 +1127,17 @@ func TestHandleOrganizationEventMemberInvited(t *testing.T) {
 				eventName:  "organization",
 				event:      &github.OrganizationEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "organization",
+				event:      &github.OrganizationEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1099,6 +1188,9 @@ func TestHandleOrganizationEventMemberInvited(t *testing.T) {
 			g.OnOrganizationEventMemberInvited(func(ctx context.Context, deliveryID string, eventName string, event *github.OrganizationEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_package.go
+++ b/githubevents/events_package.go
@@ -103,8 +103,13 @@ func (g *EventHandler) handlePackageEventPublished(ctx context.Context, delivery
 		if _, ok := g.onPackageEvent[action]; ok {
 			for _, h := range g.onPackageEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -184,8 +189,13 @@ func (g *EventHandler) handlePackageEventUpdated(ctx context.Context, deliveryID
 		if _, ok := g.onPackageEvent[action]; ok {
 			for _, h := range g.onPackageEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -256,8 +266,13 @@ func (g *EventHandler) handlePackageEventAny(ctx context.Context, deliveryID str
 	eg := new(errgroup.Group)
 	for _, h := range g.onPackageEvent[PackageEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_package_test.go
+++ b/githubevents/events_package_test.go
@@ -117,6 +117,7 @@ func TestHandlePackageEventAny(t *testing.T) {
 		eventName  string
 		event      *github.PackageEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandlePackageEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "package",
+
+				event: &github.PackageEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandlePackageEventAny(t *testing.T) {
 			g.OnPackageEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.PackageEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandlePackageEventPublished(t *testing.T) {
 		eventName  string
 		event      *github.PackageEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandlePackageEventPublished(t *testing.T) {
 				eventName:  "package",
 				event:      &github.PackageEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "package",
+				event:      &github.PackageEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandlePackageEventPublished(t *testing.T) {
 			g.OnPackageEventPublished(func(ctx context.Context, deliveryID string, eventName string, event *github.PackageEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandlePackageEventUpdated(t *testing.T) {
 		eventName  string
 		event      *github.PackageEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandlePackageEventUpdated(t *testing.T) {
 				eventName:  "package",
 				event:      &github.PackageEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "package",
+				event:      &github.PackageEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandlePackageEventUpdated(t *testing.T) {
 			g.OnPackageEventUpdated(func(ctx context.Context, deliveryID string, eventName string, event *github.PackageEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_page_build.go
+++ b/githubevents/events_page_build.go
@@ -86,8 +86,13 @@ func (g *EventHandler) handlePageBuildEventAny(ctx context.Context, deliveryID s
 	eg := new(errgroup.Group)
 	for _, h := range g.onPageBuildEvent[PageBuildEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_page_build_test.go
+++ b/githubevents/events_page_build_test.go
@@ -115,6 +115,7 @@ func TestHandlePageBuildEventAny(t *testing.T) {
 		eventName  string
 		event      *github.PageBuildEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -146,6 +147,19 @@ func TestHandlePageBuildEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "page_build",
+
+				event: &github.PageBuildEvent{},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -162,6 +176,9 @@ func TestHandlePageBuildEventAny(t *testing.T) {
 			g.OnPageBuildEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.PageBuildEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_ping.go
+++ b/githubevents/events_ping.go
@@ -86,8 +86,13 @@ func (g *EventHandler) handlePingEventAny(ctx context.Context, deliveryID string
 	eg := new(errgroup.Group)
 	for _, h := range g.onPingEvent[PingEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_ping_test.go
+++ b/githubevents/events_ping_test.go
@@ -115,6 +115,7 @@ func TestHandlePingEventAny(t *testing.T) {
 		eventName  string
 		event      *github.PingEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -146,6 +147,19 @@ func TestHandlePingEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "ping",
+
+				event: &github.PingEvent{},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -162,6 +176,9 @@ func TestHandlePingEventAny(t *testing.T) {
 			g.OnPingEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.PingEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_project_v2.go
+++ b/githubevents/events_project_v2.go
@@ -115,8 +115,13 @@ func (g *EventHandler) handleProjectEventCreated(ctx context.Context, deliveryID
 		if _, ok := g.onProjectV2Event[action]; ok {
 			for _, h := range g.onProjectV2Event[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -196,8 +201,13 @@ func (g *EventHandler) handleProjectEventEdited(ctx context.Context, deliveryID 
 		if _, ok := g.onProjectV2Event[action]; ok {
 			for _, h := range g.onProjectV2Event[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -277,8 +287,13 @@ func (g *EventHandler) handleProjectEventClosed(ctx context.Context, deliveryID 
 		if _, ok := g.onProjectV2Event[action]; ok {
 			for _, h := range g.onProjectV2Event[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -358,8 +373,13 @@ func (g *EventHandler) handleProjectEventReopened(ctx context.Context, deliveryI
 		if _, ok := g.onProjectV2Event[action]; ok {
 			for _, h := range g.onProjectV2Event[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -439,8 +459,13 @@ func (g *EventHandler) handleProjectEventDeleted(ctx context.Context, deliveryID
 		if _, ok := g.onProjectV2Event[action]; ok {
 			for _, h := range g.onProjectV2Event[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -511,8 +536,13 @@ func (g *EventHandler) handleProjectV2EventAny(ctx context.Context, deliveryID s
 	eg := new(errgroup.Group)
 	for _, h := range g.onProjectV2Event[ProjectV2EventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_project_v2_item.go
+++ b/githubevents/events_project_v2_item.go
@@ -123,8 +123,13 @@ func (g *EventHandler) handleProjectItemEventCreated(ctx context.Context, delive
 		if _, ok := g.onProjectV2ItemEvent[action]; ok {
 			for _, h := range g.onProjectV2ItemEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -204,8 +209,13 @@ func (g *EventHandler) handleProjectItemEventEdited(ctx context.Context, deliver
 		if _, ok := g.onProjectV2ItemEvent[action]; ok {
 			for _, h := range g.onProjectV2ItemEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -285,8 +295,13 @@ func (g *EventHandler) handleProjectItemEventClosed(ctx context.Context, deliver
 		if _, ok := g.onProjectV2ItemEvent[action]; ok {
 			for _, h := range g.onProjectV2ItemEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -366,8 +381,13 @@ func (g *EventHandler) handleProjectItemEventReopened(ctx context.Context, deliv
 		if _, ok := g.onProjectV2ItemEvent[action]; ok {
 			for _, h := range g.onProjectV2ItemEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -447,8 +467,13 @@ func (g *EventHandler) handleProjectItemEventDeleted(ctx context.Context, delive
 		if _, ok := g.onProjectV2ItemEvent[action]; ok {
 			for _, h := range g.onProjectV2ItemEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -528,8 +553,13 @@ func (g *EventHandler) handleProjectItemEventConverted(ctx context.Context, deli
 		if _, ok := g.onProjectV2ItemEvent[action]; ok {
 			for _, h := range g.onProjectV2ItemEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -609,8 +639,13 @@ func (g *EventHandler) handleProjectItemEventRestored(ctx context.Context, deliv
 		if _, ok := g.onProjectV2ItemEvent[action]; ok {
 			for _, h := range g.onProjectV2ItemEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -681,8 +716,13 @@ func (g *EventHandler) handleProjectV2ItemEventAny(ctx context.Context, delivery
 	eg := new(errgroup.Group)
 	for _, h := range g.onProjectV2ItemEvent[ProjectV2ItemEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_project_v2_item_test.go
+++ b/githubevents/events_project_v2_item_test.go
@@ -117,6 +117,7 @@ func TestHandleProjectV2ItemEventAny(t *testing.T) {
 		eventName  string
 		event      *github.ProjectV2ItemEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandleProjectV2ItemEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "project_v2_item",
+
+				event: &github.ProjectV2ItemEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandleProjectV2ItemEventAny(t *testing.T) {
 			g.OnProjectV2ItemEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.ProjectV2ItemEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandleProjectItemEventCreated(t *testing.T) {
 		eventName  string
 		event      *github.ProjectV2ItemEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandleProjectItemEventCreated(t *testing.T) {
 				eventName:  "project_v2_item",
 				event:      &github.ProjectV2ItemEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "project_v2_item",
+				event:      &github.ProjectV2ItemEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandleProjectItemEventCreated(t *testing.T) {
 			g.OnProjectItemEventCreated(func(ctx context.Context, deliveryID string, eventName string, event *github.ProjectV2ItemEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandleProjectItemEventEdited(t *testing.T) {
 		eventName  string
 		event      *github.ProjectV2ItemEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandleProjectItemEventEdited(t *testing.T) {
 				eventName:  "project_v2_item",
 				event:      &github.ProjectV2ItemEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "project_v2_item",
+				event:      &github.ProjectV2ItemEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandleProjectItemEventEdited(t *testing.T) {
 			g.OnProjectItemEventEdited(func(ctx context.Context, deliveryID string, eventName string, event *github.ProjectV2ItemEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -652,6 +699,7 @@ func TestHandleProjectItemEventClosed(t *testing.T) {
 		eventName  string
 		event      *github.ProjectV2ItemEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -675,6 +723,17 @@ func TestHandleProjectItemEventClosed(t *testing.T) {
 				eventName:  "project_v2_item",
 				event:      &github.ProjectV2ItemEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "project_v2_item",
+				event:      &github.ProjectV2ItemEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -725,6 +784,9 @@ func TestHandleProjectItemEventClosed(t *testing.T) {
 			g.OnProjectItemEventClosed(func(ctx context.Context, deliveryID string, eventName string, event *github.ProjectV2ItemEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -839,6 +901,7 @@ func TestHandleProjectItemEventReopened(t *testing.T) {
 		eventName  string
 		event      *github.ProjectV2ItemEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -862,6 +925,17 @@ func TestHandleProjectItemEventReopened(t *testing.T) {
 				eventName:  "project_v2_item",
 				event:      &github.ProjectV2ItemEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "project_v2_item",
+				event:      &github.ProjectV2ItemEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -912,6 +986,9 @@ func TestHandleProjectItemEventReopened(t *testing.T) {
 			g.OnProjectItemEventReopened(func(ctx context.Context, deliveryID string, eventName string, event *github.ProjectV2ItemEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1026,6 +1103,7 @@ func TestHandleProjectItemEventDeleted(t *testing.T) {
 		eventName  string
 		event      *github.ProjectV2ItemEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1049,6 +1127,17 @@ func TestHandleProjectItemEventDeleted(t *testing.T) {
 				eventName:  "project_v2_item",
 				event:      &github.ProjectV2ItemEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "project_v2_item",
+				event:      &github.ProjectV2ItemEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1099,6 +1188,9 @@ func TestHandleProjectItemEventDeleted(t *testing.T) {
 			g.OnProjectItemEventDeleted(func(ctx context.Context, deliveryID string, eventName string, event *github.ProjectV2ItemEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1213,6 +1305,7 @@ func TestHandleProjectItemEventConverted(t *testing.T) {
 		eventName  string
 		event      *github.ProjectV2ItemEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1236,6 +1329,17 @@ func TestHandleProjectItemEventConverted(t *testing.T) {
 				eventName:  "project_v2_item",
 				event:      &github.ProjectV2ItemEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "project_v2_item",
+				event:      &github.ProjectV2ItemEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1286,6 +1390,9 @@ func TestHandleProjectItemEventConverted(t *testing.T) {
 			g.OnProjectItemEventConverted(func(ctx context.Context, deliveryID string, eventName string, event *github.ProjectV2ItemEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1400,6 +1507,7 @@ func TestHandleProjectItemEventRestored(t *testing.T) {
 		eventName  string
 		event      *github.ProjectV2ItemEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1423,6 +1531,17 @@ func TestHandleProjectItemEventRestored(t *testing.T) {
 				eventName:  "project_v2_item",
 				event:      &github.ProjectV2ItemEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "project_v2_item",
+				event:      &github.ProjectV2ItemEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1473,6 +1592,9 @@ func TestHandleProjectItemEventRestored(t *testing.T) {
 			g.OnProjectItemEventRestored(func(ctx context.Context, deliveryID string, eventName string, event *github.ProjectV2ItemEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_project_v2_test.go
+++ b/githubevents/events_project_v2_test.go
@@ -117,6 +117,7 @@ func TestHandleProjectV2EventAny(t *testing.T) {
 		eventName  string
 		event      *github.ProjectV2Event
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandleProjectV2EventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "project_v2",
+
+				event: &github.ProjectV2Event{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandleProjectV2EventAny(t *testing.T) {
 			g.OnProjectV2EventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.ProjectV2Event) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandleProjectEventCreated(t *testing.T) {
 		eventName  string
 		event      *github.ProjectV2Event
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandleProjectEventCreated(t *testing.T) {
 				eventName:  "project_v2",
 				event:      &github.ProjectV2Event{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "project_v2",
+				event:      &github.ProjectV2Event{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandleProjectEventCreated(t *testing.T) {
 			g.OnProjectEventCreated(func(ctx context.Context, deliveryID string, eventName string, event *github.ProjectV2Event) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandleProjectEventEdited(t *testing.T) {
 		eventName  string
 		event      *github.ProjectV2Event
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandleProjectEventEdited(t *testing.T) {
 				eventName:  "project_v2",
 				event:      &github.ProjectV2Event{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "project_v2",
+				event:      &github.ProjectV2Event{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandleProjectEventEdited(t *testing.T) {
 			g.OnProjectEventEdited(func(ctx context.Context, deliveryID string, eventName string, event *github.ProjectV2Event) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -652,6 +699,7 @@ func TestHandleProjectEventClosed(t *testing.T) {
 		eventName  string
 		event      *github.ProjectV2Event
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -675,6 +723,17 @@ func TestHandleProjectEventClosed(t *testing.T) {
 				eventName:  "project_v2",
 				event:      &github.ProjectV2Event{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "project_v2",
+				event:      &github.ProjectV2Event{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -725,6 +784,9 @@ func TestHandleProjectEventClosed(t *testing.T) {
 			g.OnProjectEventClosed(func(ctx context.Context, deliveryID string, eventName string, event *github.ProjectV2Event) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -839,6 +901,7 @@ func TestHandleProjectEventReopened(t *testing.T) {
 		eventName  string
 		event      *github.ProjectV2Event
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -862,6 +925,17 @@ func TestHandleProjectEventReopened(t *testing.T) {
 				eventName:  "project_v2",
 				event:      &github.ProjectV2Event{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "project_v2",
+				event:      &github.ProjectV2Event{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -912,6 +986,9 @@ func TestHandleProjectEventReopened(t *testing.T) {
 			g.OnProjectEventReopened(func(ctx context.Context, deliveryID string, eventName string, event *github.ProjectV2Event) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1026,6 +1103,7 @@ func TestHandleProjectEventDeleted(t *testing.T) {
 		eventName  string
 		event      *github.ProjectV2Event
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1049,6 +1127,17 @@ func TestHandleProjectEventDeleted(t *testing.T) {
 				eventName:  "project_v2",
 				event:      &github.ProjectV2Event{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "project_v2",
+				event:      &github.ProjectV2Event{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1099,6 +1188,9 @@ func TestHandleProjectEventDeleted(t *testing.T) {
 			g.OnProjectEventDeleted(func(ctx context.Context, deliveryID string, eventName string, event *github.ProjectV2Event) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_public.go
+++ b/githubevents/events_public.go
@@ -86,8 +86,13 @@ func (g *EventHandler) handlePublicEventAny(ctx context.Context, deliveryID stri
 	eg := new(errgroup.Group)
 	for _, h := range g.onPublicEvent[PublicEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_public_test.go
+++ b/githubevents/events_public_test.go
@@ -115,6 +115,7 @@ func TestHandlePublicEventAny(t *testing.T) {
 		eventName  string
 		event      *github.PublicEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -146,6 +147,19 @@ func TestHandlePublicEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "public",
+
+				event: &github.PublicEvent{},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -162,6 +176,9 @@ func TestHandlePublicEventAny(t *testing.T) {
 			g.OnPublicEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.PublicEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_pull_request.go
+++ b/githubevents/events_pull_request.go
@@ -163,8 +163,13 @@ func (g *EventHandler) handlePullRequestEventAssigned(ctx context.Context, deliv
 		if _, ok := g.onPullRequestEvent[action]; ok {
 			for _, h := range g.onPullRequestEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -244,8 +249,13 @@ func (g *EventHandler) handlePullRequestEventAutoMergeDisabled(ctx context.Conte
 		if _, ok := g.onPullRequestEvent[action]; ok {
 			for _, h := range g.onPullRequestEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -325,8 +335,13 @@ func (g *EventHandler) handlePullRequestEventAutoMergeEnabled(ctx context.Contex
 		if _, ok := g.onPullRequestEvent[action]; ok {
 			for _, h := range g.onPullRequestEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -406,8 +421,13 @@ func (g *EventHandler) handlePullRequestEventClosed(ctx context.Context, deliver
 		if _, ok := g.onPullRequestEvent[action]; ok {
 			for _, h := range g.onPullRequestEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -487,8 +507,13 @@ func (g *EventHandler) handlePullRequestEventConvertedToDraft(ctx context.Contex
 		if _, ok := g.onPullRequestEvent[action]; ok {
 			for _, h := range g.onPullRequestEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -568,8 +593,13 @@ func (g *EventHandler) handlePullRequestEventEdited(ctx context.Context, deliver
 		if _, ok := g.onPullRequestEvent[action]; ok {
 			for _, h := range g.onPullRequestEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -649,8 +679,13 @@ func (g *EventHandler) handlePullRequestEventLabeled(ctx context.Context, delive
 		if _, ok := g.onPullRequestEvent[action]; ok {
 			for _, h := range g.onPullRequestEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -730,8 +765,13 @@ func (g *EventHandler) handlePullRequestEventLocked(ctx context.Context, deliver
 		if _, ok := g.onPullRequestEvent[action]; ok {
 			for _, h := range g.onPullRequestEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -811,8 +851,13 @@ func (g *EventHandler) handlePullRequestEventOpened(ctx context.Context, deliver
 		if _, ok := g.onPullRequestEvent[action]; ok {
 			for _, h := range g.onPullRequestEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -892,8 +937,13 @@ func (g *EventHandler) handlePullRequestEventReadyForReview(ctx context.Context,
 		if _, ok := g.onPullRequestEvent[action]; ok {
 			for _, h := range g.onPullRequestEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -973,8 +1023,13 @@ func (g *EventHandler) handlePullRequestEventReopened(ctx context.Context, deliv
 		if _, ok := g.onPullRequestEvent[action]; ok {
 			for _, h := range g.onPullRequestEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -1054,8 +1109,13 @@ func (g *EventHandler) handlePullRequestEventReviewRequestRemoved(ctx context.Co
 		if _, ok := g.onPullRequestEvent[action]; ok {
 			for _, h := range g.onPullRequestEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -1135,8 +1195,13 @@ func (g *EventHandler) handlePullRequestEventReviewRequested(ctx context.Context
 		if _, ok := g.onPullRequestEvent[action]; ok {
 			for _, h := range g.onPullRequestEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -1216,8 +1281,13 @@ func (g *EventHandler) handlePullRequestEventSynchronize(ctx context.Context, de
 		if _, ok := g.onPullRequestEvent[action]; ok {
 			for _, h := range g.onPullRequestEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -1297,8 +1367,13 @@ func (g *EventHandler) handlePullRequestEventUnassigned(ctx context.Context, del
 		if _, ok := g.onPullRequestEvent[action]; ok {
 			for _, h := range g.onPullRequestEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -1378,8 +1453,13 @@ func (g *EventHandler) handlePullRequestEventUnlabeled(ctx context.Context, deli
 		if _, ok := g.onPullRequestEvent[action]; ok {
 			for _, h := range g.onPullRequestEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -1459,8 +1539,13 @@ func (g *EventHandler) handlePullRequestEventUnlocked(ctx context.Context, deliv
 		if _, ok := g.onPullRequestEvent[action]; ok {
 			for _, h := range g.onPullRequestEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -1531,8 +1616,13 @@ func (g *EventHandler) handlePullRequestEventAny(ctx context.Context, deliveryID
 	eg := new(errgroup.Group)
 	for _, h := range g.onPullRequestEvent[PullRequestEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_pull_request_review.go
+++ b/githubevents/events_pull_request_review.go
@@ -107,8 +107,13 @@ func (g *EventHandler) handlePullRequestReviewEventSubmitted(ctx context.Context
 		if _, ok := g.onPullRequestReviewEvent[action]; ok {
 			for _, h := range g.onPullRequestReviewEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -188,8 +193,13 @@ func (g *EventHandler) handlePullRequestReviewEventEdited(ctx context.Context, d
 		if _, ok := g.onPullRequestReviewEvent[action]; ok {
 			for _, h := range g.onPullRequestReviewEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -269,8 +279,13 @@ func (g *EventHandler) handlePullRequestReviewEventDismissed(ctx context.Context
 		if _, ok := g.onPullRequestReviewEvent[action]; ok {
 			for _, h := range g.onPullRequestReviewEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -341,8 +356,13 @@ func (g *EventHandler) handlePullRequestReviewEventAny(ctx context.Context, deli
 	eg := new(errgroup.Group)
 	for _, h := range g.onPullRequestReviewEvent[PullRequestReviewEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_pull_request_review_comment.go
+++ b/githubevents/events_pull_request_review_comment.go
@@ -107,8 +107,13 @@ func (g *EventHandler) handlePullRequestReviewCommentEventCreated(ctx context.Co
 		if _, ok := g.onPullRequestReviewCommentEvent[action]; ok {
 			for _, h := range g.onPullRequestReviewCommentEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -188,8 +193,13 @@ func (g *EventHandler) handlePullRequestReviewCommentEventEdited(ctx context.Con
 		if _, ok := g.onPullRequestReviewCommentEvent[action]; ok {
 			for _, h := range g.onPullRequestReviewCommentEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -269,8 +279,13 @@ func (g *EventHandler) handlePullRequestReviewCommentEventDeleted(ctx context.Co
 		if _, ok := g.onPullRequestReviewCommentEvent[action]; ok {
 			for _, h := range g.onPullRequestReviewCommentEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -341,8 +356,13 @@ func (g *EventHandler) handlePullRequestReviewCommentEventAny(ctx context.Contex
 	eg := new(errgroup.Group)
 	for _, h := range g.onPullRequestReviewCommentEvent[PullRequestReviewCommentEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_pull_request_review_comment_test.go
+++ b/githubevents/events_pull_request_review_comment_test.go
@@ -117,6 +117,7 @@ func TestHandlePullRequestReviewCommentEventAny(t *testing.T) {
 		eventName  string
 		event      *github.PullRequestReviewCommentEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandlePullRequestReviewCommentEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "pull_request_review_comment",
+
+				event: &github.PullRequestReviewCommentEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandlePullRequestReviewCommentEventAny(t *testing.T) {
 			g.OnPullRequestReviewCommentEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.PullRequestReviewCommentEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandlePullRequestReviewCommentEventCreated(t *testing.T) {
 		eventName  string
 		event      *github.PullRequestReviewCommentEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandlePullRequestReviewCommentEventCreated(t *testing.T) {
 				eventName:  "pull_request_review_comment",
 				event:      &github.PullRequestReviewCommentEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "pull_request_review_comment",
+				event:      &github.PullRequestReviewCommentEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandlePullRequestReviewCommentEventCreated(t *testing.T) {
 			g.OnPullRequestReviewCommentEventCreated(func(ctx context.Context, deliveryID string, eventName string, event *github.PullRequestReviewCommentEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandlePullRequestReviewCommentEventEdited(t *testing.T) {
 		eventName  string
 		event      *github.PullRequestReviewCommentEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandlePullRequestReviewCommentEventEdited(t *testing.T) {
 				eventName:  "pull_request_review_comment",
 				event:      &github.PullRequestReviewCommentEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "pull_request_review_comment",
+				event:      &github.PullRequestReviewCommentEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandlePullRequestReviewCommentEventEdited(t *testing.T) {
 			g.OnPullRequestReviewCommentEventEdited(func(ctx context.Context, deliveryID string, eventName string, event *github.PullRequestReviewCommentEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -652,6 +699,7 @@ func TestHandlePullRequestReviewCommentEventDeleted(t *testing.T) {
 		eventName  string
 		event      *github.PullRequestReviewCommentEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -675,6 +723,17 @@ func TestHandlePullRequestReviewCommentEventDeleted(t *testing.T) {
 				eventName:  "pull_request_review_comment",
 				event:      &github.PullRequestReviewCommentEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "pull_request_review_comment",
+				event:      &github.PullRequestReviewCommentEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -725,6 +784,9 @@ func TestHandlePullRequestReviewCommentEventDeleted(t *testing.T) {
 			g.OnPullRequestReviewCommentEventDeleted(func(ctx context.Context, deliveryID string, eventName string, event *github.PullRequestReviewCommentEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_pull_request_review_test.go
+++ b/githubevents/events_pull_request_review_test.go
@@ -117,6 +117,7 @@ func TestHandlePullRequestReviewEventAny(t *testing.T) {
 		eventName  string
 		event      *github.PullRequestReviewEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandlePullRequestReviewEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "pull_request_review",
+
+				event: &github.PullRequestReviewEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandlePullRequestReviewEventAny(t *testing.T) {
 			g.OnPullRequestReviewEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.PullRequestReviewEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandlePullRequestReviewEventSubmitted(t *testing.T) {
 		eventName  string
 		event      *github.PullRequestReviewEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandlePullRequestReviewEventSubmitted(t *testing.T) {
 				eventName:  "pull_request_review",
 				event:      &github.PullRequestReviewEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "pull_request_review",
+				event:      &github.PullRequestReviewEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandlePullRequestReviewEventSubmitted(t *testing.T) {
 			g.OnPullRequestReviewEventSubmitted(func(ctx context.Context, deliveryID string, eventName string, event *github.PullRequestReviewEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandlePullRequestReviewEventEdited(t *testing.T) {
 		eventName  string
 		event      *github.PullRequestReviewEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandlePullRequestReviewEventEdited(t *testing.T) {
 				eventName:  "pull_request_review",
 				event:      &github.PullRequestReviewEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "pull_request_review",
+				event:      &github.PullRequestReviewEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandlePullRequestReviewEventEdited(t *testing.T) {
 			g.OnPullRequestReviewEventEdited(func(ctx context.Context, deliveryID string, eventName string, event *github.PullRequestReviewEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -652,6 +699,7 @@ func TestHandlePullRequestReviewEventDismissed(t *testing.T) {
 		eventName  string
 		event      *github.PullRequestReviewEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -675,6 +723,17 @@ func TestHandlePullRequestReviewEventDismissed(t *testing.T) {
 				eventName:  "pull_request_review",
 				event:      &github.PullRequestReviewEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "pull_request_review",
+				event:      &github.PullRequestReviewEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -725,6 +784,9 @@ func TestHandlePullRequestReviewEventDismissed(t *testing.T) {
 			g.OnPullRequestReviewEventDismissed(func(ctx context.Context, deliveryID string, eventName string, event *github.PullRequestReviewEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_pull_request_test.go
+++ b/githubevents/events_pull_request_test.go
@@ -117,6 +117,7 @@ func TestHandlePullRequestEventAny(t *testing.T) {
 		eventName  string
 		event      *github.PullRequestEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandlePullRequestEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "pull_request",
+
+				event: &github.PullRequestEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandlePullRequestEventAny(t *testing.T) {
 			g.OnPullRequestEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.PullRequestEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandlePullRequestEventAssigned(t *testing.T) {
 		eventName  string
 		event      *github.PullRequestEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandlePullRequestEventAssigned(t *testing.T) {
 				eventName:  "pull_request",
 				event:      &github.PullRequestEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "pull_request",
+				event:      &github.PullRequestEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandlePullRequestEventAssigned(t *testing.T) {
 			g.OnPullRequestEventAssigned(func(ctx context.Context, deliveryID string, eventName string, event *github.PullRequestEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandlePullRequestEventAutoMergeDisabled(t *testing.T) {
 		eventName  string
 		event      *github.PullRequestEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandlePullRequestEventAutoMergeDisabled(t *testing.T) {
 				eventName:  "pull_request",
 				event:      &github.PullRequestEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "pull_request",
+				event:      &github.PullRequestEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandlePullRequestEventAutoMergeDisabled(t *testing.T) {
 			g.OnPullRequestEventAutoMergeDisabled(func(ctx context.Context, deliveryID string, eventName string, event *github.PullRequestEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -652,6 +699,7 @@ func TestHandlePullRequestEventAutoMergeEnabled(t *testing.T) {
 		eventName  string
 		event      *github.PullRequestEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -675,6 +723,17 @@ func TestHandlePullRequestEventAutoMergeEnabled(t *testing.T) {
 				eventName:  "pull_request",
 				event:      &github.PullRequestEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "pull_request",
+				event:      &github.PullRequestEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -725,6 +784,9 @@ func TestHandlePullRequestEventAutoMergeEnabled(t *testing.T) {
 			g.OnPullRequestEventAutoMergeEnabled(func(ctx context.Context, deliveryID string, eventName string, event *github.PullRequestEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -839,6 +901,7 @@ func TestHandlePullRequestEventClosed(t *testing.T) {
 		eventName  string
 		event      *github.PullRequestEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -862,6 +925,17 @@ func TestHandlePullRequestEventClosed(t *testing.T) {
 				eventName:  "pull_request",
 				event:      &github.PullRequestEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "pull_request",
+				event:      &github.PullRequestEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -912,6 +986,9 @@ func TestHandlePullRequestEventClosed(t *testing.T) {
 			g.OnPullRequestEventClosed(func(ctx context.Context, deliveryID string, eventName string, event *github.PullRequestEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1026,6 +1103,7 @@ func TestHandlePullRequestEventConvertedToDraft(t *testing.T) {
 		eventName  string
 		event      *github.PullRequestEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1049,6 +1127,17 @@ func TestHandlePullRequestEventConvertedToDraft(t *testing.T) {
 				eventName:  "pull_request",
 				event:      &github.PullRequestEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "pull_request",
+				event:      &github.PullRequestEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1099,6 +1188,9 @@ func TestHandlePullRequestEventConvertedToDraft(t *testing.T) {
 			g.OnPullRequestEventConvertedToDraft(func(ctx context.Context, deliveryID string, eventName string, event *github.PullRequestEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1213,6 +1305,7 @@ func TestHandlePullRequestEventEdited(t *testing.T) {
 		eventName  string
 		event      *github.PullRequestEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1236,6 +1329,17 @@ func TestHandlePullRequestEventEdited(t *testing.T) {
 				eventName:  "pull_request",
 				event:      &github.PullRequestEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "pull_request",
+				event:      &github.PullRequestEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1286,6 +1390,9 @@ func TestHandlePullRequestEventEdited(t *testing.T) {
 			g.OnPullRequestEventEdited(func(ctx context.Context, deliveryID string, eventName string, event *github.PullRequestEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1400,6 +1507,7 @@ func TestHandlePullRequestEventLabeled(t *testing.T) {
 		eventName  string
 		event      *github.PullRequestEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1423,6 +1531,17 @@ func TestHandlePullRequestEventLabeled(t *testing.T) {
 				eventName:  "pull_request",
 				event:      &github.PullRequestEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "pull_request",
+				event:      &github.PullRequestEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1473,6 +1592,9 @@ func TestHandlePullRequestEventLabeled(t *testing.T) {
 			g.OnPullRequestEventLabeled(func(ctx context.Context, deliveryID string, eventName string, event *github.PullRequestEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1587,6 +1709,7 @@ func TestHandlePullRequestEventLocked(t *testing.T) {
 		eventName  string
 		event      *github.PullRequestEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1610,6 +1733,17 @@ func TestHandlePullRequestEventLocked(t *testing.T) {
 				eventName:  "pull_request",
 				event:      &github.PullRequestEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "pull_request",
+				event:      &github.PullRequestEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1660,6 +1794,9 @@ func TestHandlePullRequestEventLocked(t *testing.T) {
 			g.OnPullRequestEventLocked(func(ctx context.Context, deliveryID string, eventName string, event *github.PullRequestEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1774,6 +1911,7 @@ func TestHandlePullRequestEventOpened(t *testing.T) {
 		eventName  string
 		event      *github.PullRequestEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1797,6 +1935,17 @@ func TestHandlePullRequestEventOpened(t *testing.T) {
 				eventName:  "pull_request",
 				event:      &github.PullRequestEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "pull_request",
+				event:      &github.PullRequestEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1847,6 +1996,9 @@ func TestHandlePullRequestEventOpened(t *testing.T) {
 			g.OnPullRequestEventOpened(func(ctx context.Context, deliveryID string, eventName string, event *github.PullRequestEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1961,6 +2113,7 @@ func TestHandlePullRequestEventReadyForReview(t *testing.T) {
 		eventName  string
 		event      *github.PullRequestEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1984,6 +2137,17 @@ func TestHandlePullRequestEventReadyForReview(t *testing.T) {
 				eventName:  "pull_request",
 				event:      &github.PullRequestEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "pull_request",
+				event:      &github.PullRequestEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -2034,6 +2198,9 @@ func TestHandlePullRequestEventReadyForReview(t *testing.T) {
 			g.OnPullRequestEventReadyForReview(func(ctx context.Context, deliveryID string, eventName string, event *github.PullRequestEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -2148,6 +2315,7 @@ func TestHandlePullRequestEventReopened(t *testing.T) {
 		eventName  string
 		event      *github.PullRequestEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -2171,6 +2339,17 @@ func TestHandlePullRequestEventReopened(t *testing.T) {
 				eventName:  "pull_request",
 				event:      &github.PullRequestEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "pull_request",
+				event:      &github.PullRequestEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -2221,6 +2400,9 @@ func TestHandlePullRequestEventReopened(t *testing.T) {
 			g.OnPullRequestEventReopened(func(ctx context.Context, deliveryID string, eventName string, event *github.PullRequestEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -2335,6 +2517,7 @@ func TestHandlePullRequestEventReviewRequestRemoved(t *testing.T) {
 		eventName  string
 		event      *github.PullRequestEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -2358,6 +2541,17 @@ func TestHandlePullRequestEventReviewRequestRemoved(t *testing.T) {
 				eventName:  "pull_request",
 				event:      &github.PullRequestEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "pull_request",
+				event:      &github.PullRequestEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -2408,6 +2602,9 @@ func TestHandlePullRequestEventReviewRequestRemoved(t *testing.T) {
 			g.OnPullRequestEventReviewRequestRemoved(func(ctx context.Context, deliveryID string, eventName string, event *github.PullRequestEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -2522,6 +2719,7 @@ func TestHandlePullRequestEventReviewRequested(t *testing.T) {
 		eventName  string
 		event      *github.PullRequestEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -2545,6 +2743,17 @@ func TestHandlePullRequestEventReviewRequested(t *testing.T) {
 				eventName:  "pull_request",
 				event:      &github.PullRequestEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "pull_request",
+				event:      &github.PullRequestEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -2595,6 +2804,9 @@ func TestHandlePullRequestEventReviewRequested(t *testing.T) {
 			g.OnPullRequestEventReviewRequested(func(ctx context.Context, deliveryID string, eventName string, event *github.PullRequestEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -2709,6 +2921,7 @@ func TestHandlePullRequestEventSynchronize(t *testing.T) {
 		eventName  string
 		event      *github.PullRequestEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -2732,6 +2945,17 @@ func TestHandlePullRequestEventSynchronize(t *testing.T) {
 				eventName:  "pull_request",
 				event:      &github.PullRequestEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "pull_request",
+				event:      &github.PullRequestEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -2782,6 +3006,9 @@ func TestHandlePullRequestEventSynchronize(t *testing.T) {
 			g.OnPullRequestEventSynchronize(func(ctx context.Context, deliveryID string, eventName string, event *github.PullRequestEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -2896,6 +3123,7 @@ func TestHandlePullRequestEventUnassigned(t *testing.T) {
 		eventName  string
 		event      *github.PullRequestEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -2919,6 +3147,17 @@ func TestHandlePullRequestEventUnassigned(t *testing.T) {
 				eventName:  "pull_request",
 				event:      &github.PullRequestEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "pull_request",
+				event:      &github.PullRequestEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -2969,6 +3208,9 @@ func TestHandlePullRequestEventUnassigned(t *testing.T) {
 			g.OnPullRequestEventUnassigned(func(ctx context.Context, deliveryID string, eventName string, event *github.PullRequestEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -3083,6 +3325,7 @@ func TestHandlePullRequestEventUnlabeled(t *testing.T) {
 		eventName  string
 		event      *github.PullRequestEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -3106,6 +3349,17 @@ func TestHandlePullRequestEventUnlabeled(t *testing.T) {
 				eventName:  "pull_request",
 				event:      &github.PullRequestEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "pull_request",
+				event:      &github.PullRequestEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -3156,6 +3410,9 @@ func TestHandlePullRequestEventUnlabeled(t *testing.T) {
 			g.OnPullRequestEventUnlabeled(func(ctx context.Context, deliveryID string, eventName string, event *github.PullRequestEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -3270,6 +3527,7 @@ func TestHandlePullRequestEventUnlocked(t *testing.T) {
 		eventName  string
 		event      *github.PullRequestEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -3293,6 +3551,17 @@ func TestHandlePullRequestEventUnlocked(t *testing.T) {
 				eventName:  "pull_request",
 				event:      &github.PullRequestEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "pull_request",
+				event:      &github.PullRequestEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -3343,6 +3612,9 @@ func TestHandlePullRequestEventUnlocked(t *testing.T) {
 			g.OnPullRequestEventUnlocked(func(ctx context.Context, deliveryID string, eventName string, event *github.PullRequestEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_push.go
+++ b/githubevents/events_push.go
@@ -86,8 +86,13 @@ func (g *EventHandler) handlePushEventAny(ctx context.Context, deliveryID string
 	eg := new(errgroup.Group)
 	for _, h := range g.onPushEvent[PushEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_push_test.go
+++ b/githubevents/events_push_test.go
@@ -115,6 +115,7 @@ func TestHandlePushEventAny(t *testing.T) {
 		eventName  string
 		event      *github.PushEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -146,6 +147,19 @@ func TestHandlePushEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "push",
+
+				event: &github.PushEvent{},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -162,6 +176,9 @@ func TestHandlePushEventAny(t *testing.T) {
 			g.OnPushEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.PushEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_release.go
+++ b/githubevents/events_release.go
@@ -123,8 +123,13 @@ func (g *EventHandler) handleReleaseEventPublished(ctx context.Context, delivery
 		if _, ok := g.onReleaseEvent[action]; ok {
 			for _, h := range g.onReleaseEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -204,8 +209,13 @@ func (g *EventHandler) handleReleaseEventUnpublished(ctx context.Context, delive
 		if _, ok := g.onReleaseEvent[action]; ok {
 			for _, h := range g.onReleaseEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -285,8 +295,13 @@ func (g *EventHandler) handleReleaseEventCreated(ctx context.Context, deliveryID
 		if _, ok := g.onReleaseEvent[action]; ok {
 			for _, h := range g.onReleaseEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -366,8 +381,13 @@ func (g *EventHandler) handleReleaseEventEdited(ctx context.Context, deliveryID 
 		if _, ok := g.onReleaseEvent[action]; ok {
 			for _, h := range g.onReleaseEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -447,8 +467,13 @@ func (g *EventHandler) handleReleaseEventDeleted(ctx context.Context, deliveryID
 		if _, ok := g.onReleaseEvent[action]; ok {
 			for _, h := range g.onReleaseEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -528,8 +553,13 @@ func (g *EventHandler) handleReleaseEventPreReleased(ctx context.Context, delive
 		if _, ok := g.onReleaseEvent[action]; ok {
 			for _, h := range g.onReleaseEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -609,8 +639,13 @@ func (g *EventHandler) handleReleaseEventReleased(ctx context.Context, deliveryI
 		if _, ok := g.onReleaseEvent[action]; ok {
 			for _, h := range g.onReleaseEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -681,8 +716,13 @@ func (g *EventHandler) handleReleaseEventAny(ctx context.Context, deliveryID str
 	eg := new(errgroup.Group)
 	for _, h := range g.onReleaseEvent[ReleaseEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_release_test.go
+++ b/githubevents/events_release_test.go
@@ -117,6 +117,7 @@ func TestHandleReleaseEventAny(t *testing.T) {
 		eventName  string
 		event      *github.ReleaseEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandleReleaseEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "release",
+
+				event: &github.ReleaseEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandleReleaseEventAny(t *testing.T) {
 			g.OnReleaseEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.ReleaseEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandleReleaseEventPublished(t *testing.T) {
 		eventName  string
 		event      *github.ReleaseEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandleReleaseEventPublished(t *testing.T) {
 				eventName:  "release",
 				event:      &github.ReleaseEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "release",
+				event:      &github.ReleaseEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandleReleaseEventPublished(t *testing.T) {
 			g.OnReleaseEventPublished(func(ctx context.Context, deliveryID string, eventName string, event *github.ReleaseEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandleReleaseEventUnpublished(t *testing.T) {
 		eventName  string
 		event      *github.ReleaseEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandleReleaseEventUnpublished(t *testing.T) {
 				eventName:  "release",
 				event:      &github.ReleaseEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "release",
+				event:      &github.ReleaseEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandleReleaseEventUnpublished(t *testing.T) {
 			g.OnReleaseEventUnpublished(func(ctx context.Context, deliveryID string, eventName string, event *github.ReleaseEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -652,6 +699,7 @@ func TestHandleReleaseEventCreated(t *testing.T) {
 		eventName  string
 		event      *github.ReleaseEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -675,6 +723,17 @@ func TestHandleReleaseEventCreated(t *testing.T) {
 				eventName:  "release",
 				event:      &github.ReleaseEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "release",
+				event:      &github.ReleaseEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -725,6 +784,9 @@ func TestHandleReleaseEventCreated(t *testing.T) {
 			g.OnReleaseEventCreated(func(ctx context.Context, deliveryID string, eventName string, event *github.ReleaseEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -839,6 +901,7 @@ func TestHandleReleaseEventEdited(t *testing.T) {
 		eventName  string
 		event      *github.ReleaseEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -862,6 +925,17 @@ func TestHandleReleaseEventEdited(t *testing.T) {
 				eventName:  "release",
 				event:      &github.ReleaseEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "release",
+				event:      &github.ReleaseEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -912,6 +986,9 @@ func TestHandleReleaseEventEdited(t *testing.T) {
 			g.OnReleaseEventEdited(func(ctx context.Context, deliveryID string, eventName string, event *github.ReleaseEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1026,6 +1103,7 @@ func TestHandleReleaseEventDeleted(t *testing.T) {
 		eventName  string
 		event      *github.ReleaseEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1049,6 +1127,17 @@ func TestHandleReleaseEventDeleted(t *testing.T) {
 				eventName:  "release",
 				event:      &github.ReleaseEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "release",
+				event:      &github.ReleaseEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1099,6 +1188,9 @@ func TestHandleReleaseEventDeleted(t *testing.T) {
 			g.OnReleaseEventDeleted(func(ctx context.Context, deliveryID string, eventName string, event *github.ReleaseEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1213,6 +1305,7 @@ func TestHandleReleaseEventPreReleased(t *testing.T) {
 		eventName  string
 		event      *github.ReleaseEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1236,6 +1329,17 @@ func TestHandleReleaseEventPreReleased(t *testing.T) {
 				eventName:  "release",
 				event:      &github.ReleaseEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "release",
+				event:      &github.ReleaseEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1286,6 +1390,9 @@ func TestHandleReleaseEventPreReleased(t *testing.T) {
 			g.OnReleaseEventPreReleased(func(ctx context.Context, deliveryID string, eventName string, event *github.ReleaseEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1400,6 +1507,7 @@ func TestHandleReleaseEventReleased(t *testing.T) {
 		eventName  string
 		event      *github.ReleaseEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1423,6 +1531,17 @@ func TestHandleReleaseEventReleased(t *testing.T) {
 				eventName:  "release",
 				event:      &github.ReleaseEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "release",
+				event:      &github.ReleaseEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1473,6 +1592,9 @@ func TestHandleReleaseEventReleased(t *testing.T) {
 			g.OnReleaseEventReleased(func(ctx context.Context, deliveryID string, eventName string, event *github.ReleaseEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_repository.go
+++ b/githubevents/events_repository.go
@@ -131,8 +131,13 @@ func (g *EventHandler) handleRepositoryEventCreated(ctx context.Context, deliver
 		if _, ok := g.onRepositoryEvent[action]; ok {
 			for _, h := range g.onRepositoryEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -212,8 +217,13 @@ func (g *EventHandler) handleRepositoryEventDeleted(ctx context.Context, deliver
 		if _, ok := g.onRepositoryEvent[action]; ok {
 			for _, h := range g.onRepositoryEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -293,8 +303,13 @@ func (g *EventHandler) handleRepositoryEventArchived(ctx context.Context, delive
 		if _, ok := g.onRepositoryEvent[action]; ok {
 			for _, h := range g.onRepositoryEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -374,8 +389,13 @@ func (g *EventHandler) handleRepositoryEventUnarchived(ctx context.Context, deli
 		if _, ok := g.onRepositoryEvent[action]; ok {
 			for _, h := range g.onRepositoryEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -455,8 +475,13 @@ func (g *EventHandler) handleRepositoryEventEdited(ctx context.Context, delivery
 		if _, ok := g.onRepositoryEvent[action]; ok {
 			for _, h := range g.onRepositoryEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -536,8 +561,13 @@ func (g *EventHandler) handleRepositoryEventRenamed(ctx context.Context, deliver
 		if _, ok := g.onRepositoryEvent[action]; ok {
 			for _, h := range g.onRepositoryEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -617,8 +647,13 @@ func (g *EventHandler) handleRepositoryEventTransferred(ctx context.Context, del
 		if _, ok := g.onRepositoryEvent[action]; ok {
 			for _, h := range g.onRepositoryEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -698,8 +733,13 @@ func (g *EventHandler) handleRepositoryEventPublicized(ctx context.Context, deli
 		if _, ok := g.onRepositoryEvent[action]; ok {
 			for _, h := range g.onRepositoryEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -779,8 +819,13 @@ func (g *EventHandler) handleRepositoryEventPrivatized(ctx context.Context, deli
 		if _, ok := g.onRepositoryEvent[action]; ok {
 			for _, h := range g.onRepositoryEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -851,8 +896,13 @@ func (g *EventHandler) handleRepositoryEventAny(ctx context.Context, deliveryID 
 	eg := new(errgroup.Group)
 	for _, h := range g.onRepositoryEvent[RepositoryEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_repository_dispatch.go
+++ b/githubevents/events_repository_dispatch.go
@@ -86,8 +86,13 @@ func (g *EventHandler) handleRepositoryDispatchEventAny(ctx context.Context, del
 	eg := new(errgroup.Group)
 	for _, h := range g.onRepositoryDispatchEvent[RepositoryDispatchEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_repository_dispatch_test.go
+++ b/githubevents/events_repository_dispatch_test.go
@@ -115,6 +115,7 @@ func TestHandleRepositoryDispatchEventAny(t *testing.T) {
 		eventName  string
 		event      *github.RepositoryDispatchEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -146,6 +147,19 @@ func TestHandleRepositoryDispatchEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "repository_dispatch",
+
+				event: &github.RepositoryDispatchEvent{},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -162,6 +176,9 @@ func TestHandleRepositoryDispatchEventAny(t *testing.T) {
 			g.OnRepositoryDispatchEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.RepositoryDispatchEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_repository_ruleset.go
+++ b/githubevents/events_repository_ruleset.go
@@ -107,8 +107,13 @@ func (g *EventHandler) handleRepositoryRulesetEventCreated(ctx context.Context, 
 		if _, ok := g.onRepositoryRulesetEvent[action]; ok {
 			for _, h := range g.onRepositoryRulesetEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -188,8 +193,13 @@ func (g *EventHandler) handleRepositoryRulesetEventDeleted(ctx context.Context, 
 		if _, ok := g.onRepositoryRulesetEvent[action]; ok {
 			for _, h := range g.onRepositoryRulesetEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -269,8 +279,13 @@ func (g *EventHandler) handleRepositoryRulesetEventEdited(ctx context.Context, d
 		if _, ok := g.onRepositoryRulesetEvent[action]; ok {
 			for _, h := range g.onRepositoryRulesetEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -341,8 +356,13 @@ func (g *EventHandler) handleRepositoryRulesetEventAny(ctx context.Context, deli
 	eg := new(errgroup.Group)
 	for _, h := range g.onRepositoryRulesetEvent[RepositoryRulesetEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_repository_ruleset_test.go
+++ b/githubevents/events_repository_ruleset_test.go
@@ -117,6 +117,7 @@ func TestHandleRepositoryRulesetEventAny(t *testing.T) {
 		eventName  string
 		event      *github.RepositoryRulesetEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandleRepositoryRulesetEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "repository_ruleset",
+
+				event: &github.RepositoryRulesetEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandleRepositoryRulesetEventAny(t *testing.T) {
 			g.OnRepositoryRulesetEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.RepositoryRulesetEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandleRepositoryRulesetEventCreated(t *testing.T) {
 		eventName  string
 		event      *github.RepositoryRulesetEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandleRepositoryRulesetEventCreated(t *testing.T) {
 				eventName:  "repository_ruleset",
 				event:      &github.RepositoryRulesetEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "repository_ruleset",
+				event:      &github.RepositoryRulesetEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandleRepositoryRulesetEventCreated(t *testing.T) {
 			g.OnRepositoryRulesetEventCreated(func(ctx context.Context, deliveryID string, eventName string, event *github.RepositoryRulesetEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandleRepositoryRulesetEventDeleted(t *testing.T) {
 		eventName  string
 		event      *github.RepositoryRulesetEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandleRepositoryRulesetEventDeleted(t *testing.T) {
 				eventName:  "repository_ruleset",
 				event:      &github.RepositoryRulesetEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "repository_ruleset",
+				event:      &github.RepositoryRulesetEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandleRepositoryRulesetEventDeleted(t *testing.T) {
 			g.OnRepositoryRulesetEventDeleted(func(ctx context.Context, deliveryID string, eventName string, event *github.RepositoryRulesetEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -652,6 +699,7 @@ func TestHandleRepositoryRulesetEventEdited(t *testing.T) {
 		eventName  string
 		event      *github.RepositoryRulesetEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -675,6 +723,17 @@ func TestHandleRepositoryRulesetEventEdited(t *testing.T) {
 				eventName:  "repository_ruleset",
 				event:      &github.RepositoryRulesetEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "repository_ruleset",
+				event:      &github.RepositoryRulesetEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -725,6 +784,9 @@ func TestHandleRepositoryRulesetEventEdited(t *testing.T) {
 			g.OnRepositoryRulesetEventEdited(func(ctx context.Context, deliveryID string, eventName string, event *github.RepositoryRulesetEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_repository_test.go
+++ b/githubevents/events_repository_test.go
@@ -117,6 +117,7 @@ func TestHandleRepositoryEventAny(t *testing.T) {
 		eventName  string
 		event      *github.RepositoryEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandleRepositoryEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "repository",
+
+				event: &github.RepositoryEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandleRepositoryEventAny(t *testing.T) {
 			g.OnRepositoryEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.RepositoryEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandleRepositoryEventCreated(t *testing.T) {
 		eventName  string
 		event      *github.RepositoryEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandleRepositoryEventCreated(t *testing.T) {
 				eventName:  "repository",
 				event:      &github.RepositoryEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "repository",
+				event:      &github.RepositoryEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandleRepositoryEventCreated(t *testing.T) {
 			g.OnRepositoryEventCreated(func(ctx context.Context, deliveryID string, eventName string, event *github.RepositoryEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandleRepositoryEventDeleted(t *testing.T) {
 		eventName  string
 		event      *github.RepositoryEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandleRepositoryEventDeleted(t *testing.T) {
 				eventName:  "repository",
 				event:      &github.RepositoryEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "repository",
+				event:      &github.RepositoryEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandleRepositoryEventDeleted(t *testing.T) {
 			g.OnRepositoryEventDeleted(func(ctx context.Context, deliveryID string, eventName string, event *github.RepositoryEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -652,6 +699,7 @@ func TestHandleRepositoryEventArchived(t *testing.T) {
 		eventName  string
 		event      *github.RepositoryEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -675,6 +723,17 @@ func TestHandleRepositoryEventArchived(t *testing.T) {
 				eventName:  "repository",
 				event:      &github.RepositoryEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "repository",
+				event:      &github.RepositoryEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -725,6 +784,9 @@ func TestHandleRepositoryEventArchived(t *testing.T) {
 			g.OnRepositoryEventArchived(func(ctx context.Context, deliveryID string, eventName string, event *github.RepositoryEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -839,6 +901,7 @@ func TestHandleRepositoryEventUnarchived(t *testing.T) {
 		eventName  string
 		event      *github.RepositoryEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -862,6 +925,17 @@ func TestHandleRepositoryEventUnarchived(t *testing.T) {
 				eventName:  "repository",
 				event:      &github.RepositoryEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "repository",
+				event:      &github.RepositoryEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -912,6 +986,9 @@ func TestHandleRepositoryEventUnarchived(t *testing.T) {
 			g.OnRepositoryEventUnarchived(func(ctx context.Context, deliveryID string, eventName string, event *github.RepositoryEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1026,6 +1103,7 @@ func TestHandleRepositoryEventEdited(t *testing.T) {
 		eventName  string
 		event      *github.RepositoryEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1049,6 +1127,17 @@ func TestHandleRepositoryEventEdited(t *testing.T) {
 				eventName:  "repository",
 				event:      &github.RepositoryEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "repository",
+				event:      &github.RepositoryEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1099,6 +1188,9 @@ func TestHandleRepositoryEventEdited(t *testing.T) {
 			g.OnRepositoryEventEdited(func(ctx context.Context, deliveryID string, eventName string, event *github.RepositoryEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1213,6 +1305,7 @@ func TestHandleRepositoryEventRenamed(t *testing.T) {
 		eventName  string
 		event      *github.RepositoryEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1236,6 +1329,17 @@ func TestHandleRepositoryEventRenamed(t *testing.T) {
 				eventName:  "repository",
 				event:      &github.RepositoryEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "repository",
+				event:      &github.RepositoryEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1286,6 +1390,9 @@ func TestHandleRepositoryEventRenamed(t *testing.T) {
 			g.OnRepositoryEventRenamed(func(ctx context.Context, deliveryID string, eventName string, event *github.RepositoryEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1400,6 +1507,7 @@ func TestHandleRepositoryEventTransferred(t *testing.T) {
 		eventName  string
 		event      *github.RepositoryEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1423,6 +1531,17 @@ func TestHandleRepositoryEventTransferred(t *testing.T) {
 				eventName:  "repository",
 				event:      &github.RepositoryEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "repository",
+				event:      &github.RepositoryEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1473,6 +1592,9 @@ func TestHandleRepositoryEventTransferred(t *testing.T) {
 			g.OnRepositoryEventTransferred(func(ctx context.Context, deliveryID string, eventName string, event *github.RepositoryEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1587,6 +1709,7 @@ func TestHandleRepositoryEventPublicized(t *testing.T) {
 		eventName  string
 		event      *github.RepositoryEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1610,6 +1733,17 @@ func TestHandleRepositoryEventPublicized(t *testing.T) {
 				eventName:  "repository",
 				event:      &github.RepositoryEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "repository",
+				event:      &github.RepositoryEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1660,6 +1794,9 @@ func TestHandleRepositoryEventPublicized(t *testing.T) {
 			g.OnRepositoryEventPublicized(func(ctx context.Context, deliveryID string, eventName string, event *github.RepositoryEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1774,6 +1911,7 @@ func TestHandleRepositoryEventPrivatized(t *testing.T) {
 		eventName  string
 		event      *github.RepositoryEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1797,6 +1935,17 @@ func TestHandleRepositoryEventPrivatized(t *testing.T) {
 				eventName:  "repository",
 				event:      &github.RepositoryEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "repository",
+				event:      &github.RepositoryEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1847,6 +1996,9 @@ func TestHandleRepositoryEventPrivatized(t *testing.T) {
 			g.OnRepositoryEventPrivatized(func(ctx context.Context, deliveryID string, eventName string, event *github.RepositoryEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_repository_vulnerability_alert.go
+++ b/githubevents/events_repository_vulnerability_alert.go
@@ -107,8 +107,13 @@ func (g *EventHandler) handleRepositoryVulnerabilityAlertEventCreate(ctx context
 		if _, ok := g.onRepositoryVulnerabilityAlertEvent[action]; ok {
 			for _, h := range g.onRepositoryVulnerabilityAlertEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -188,8 +193,13 @@ func (g *EventHandler) handleRepositoryVulnerabilityAlertEventDismiss(ctx contex
 		if _, ok := g.onRepositoryVulnerabilityAlertEvent[action]; ok {
 			for _, h := range g.onRepositoryVulnerabilityAlertEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -269,8 +279,13 @@ func (g *EventHandler) handleRepositoryVulnerabilityAlertEventResolve(ctx contex
 		if _, ok := g.onRepositoryVulnerabilityAlertEvent[action]; ok {
 			for _, h := range g.onRepositoryVulnerabilityAlertEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -341,8 +356,13 @@ func (g *EventHandler) handleRepositoryVulnerabilityAlertEventAny(ctx context.Co
 	eg := new(errgroup.Group)
 	for _, h := range g.onRepositoryVulnerabilityAlertEvent[RepositoryVulnerabilityAlertEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_repository_vulnerability_alert_test.go
+++ b/githubevents/events_repository_vulnerability_alert_test.go
@@ -117,6 +117,7 @@ func TestHandleRepositoryVulnerabilityAlertEventAny(t *testing.T) {
 		eventName  string
 		event      *github.RepositoryVulnerabilityAlertEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandleRepositoryVulnerabilityAlertEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "repository_vulnerability_alert",
+
+				event: &github.RepositoryVulnerabilityAlertEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandleRepositoryVulnerabilityAlertEventAny(t *testing.T) {
 			g.OnRepositoryVulnerabilityAlertEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.RepositoryVulnerabilityAlertEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandleRepositoryVulnerabilityAlertEventCreate(t *testing.T) {
 		eventName  string
 		event      *github.RepositoryVulnerabilityAlertEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandleRepositoryVulnerabilityAlertEventCreate(t *testing.T) {
 				eventName:  "repository_vulnerability_alert",
 				event:      &github.RepositoryVulnerabilityAlertEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "repository_vulnerability_alert",
+				event:      &github.RepositoryVulnerabilityAlertEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandleRepositoryVulnerabilityAlertEventCreate(t *testing.T) {
 			g.OnRepositoryVulnerabilityAlertEventCreate(func(ctx context.Context, deliveryID string, eventName string, event *github.RepositoryVulnerabilityAlertEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandleRepositoryVulnerabilityAlertEventDismiss(t *testing.T) {
 		eventName  string
 		event      *github.RepositoryVulnerabilityAlertEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandleRepositoryVulnerabilityAlertEventDismiss(t *testing.T) {
 				eventName:  "repository_vulnerability_alert",
 				event:      &github.RepositoryVulnerabilityAlertEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "repository_vulnerability_alert",
+				event:      &github.RepositoryVulnerabilityAlertEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandleRepositoryVulnerabilityAlertEventDismiss(t *testing.T) {
 			g.OnRepositoryVulnerabilityAlertEventDismiss(func(ctx context.Context, deliveryID string, eventName string, event *github.RepositoryVulnerabilityAlertEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -652,6 +699,7 @@ func TestHandleRepositoryVulnerabilityAlertEventResolve(t *testing.T) {
 		eventName  string
 		event      *github.RepositoryVulnerabilityAlertEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -675,6 +723,17 @@ func TestHandleRepositoryVulnerabilityAlertEventResolve(t *testing.T) {
 				eventName:  "repository_vulnerability_alert",
 				event:      &github.RepositoryVulnerabilityAlertEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "repository_vulnerability_alert",
+				event:      &github.RepositoryVulnerabilityAlertEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -725,6 +784,9 @@ func TestHandleRepositoryVulnerabilityAlertEventResolve(t *testing.T) {
 			g.OnRepositoryVulnerabilityAlertEventResolve(func(ctx context.Context, deliveryID string, eventName string, event *github.RepositoryVulnerabilityAlertEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_star.go
+++ b/githubevents/events_star.go
@@ -103,8 +103,13 @@ func (g *EventHandler) handleStarEventCreated(ctx context.Context, deliveryID st
 		if _, ok := g.onStarEvent[action]; ok {
 			for _, h := range g.onStarEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -184,8 +189,13 @@ func (g *EventHandler) handleStarEventDeleted(ctx context.Context, deliveryID st
 		if _, ok := g.onStarEvent[action]; ok {
 			for _, h := range g.onStarEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -256,8 +266,13 @@ func (g *EventHandler) handleStarEventAny(ctx context.Context, deliveryID string
 	eg := new(errgroup.Group)
 	for _, h := range g.onStarEvent[StarEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_star_test.go
+++ b/githubevents/events_star_test.go
@@ -117,6 +117,7 @@ func TestHandleStarEventAny(t *testing.T) {
 		eventName  string
 		event      *github.StarEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandleStarEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "star",
+
+				event: &github.StarEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandleStarEventAny(t *testing.T) {
 			g.OnStarEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.StarEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandleStarEventCreated(t *testing.T) {
 		eventName  string
 		event      *github.StarEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandleStarEventCreated(t *testing.T) {
 				eventName:  "star",
 				event:      &github.StarEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "star",
+				event:      &github.StarEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandleStarEventCreated(t *testing.T) {
 			g.OnStarEventCreated(func(ctx context.Context, deliveryID string, eventName string, event *github.StarEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandleStarEventDeleted(t *testing.T) {
 		eventName  string
 		event      *github.StarEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandleStarEventDeleted(t *testing.T) {
 				eventName:  "star",
 				event:      &github.StarEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "star",
+				event:      &github.StarEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandleStarEventDeleted(t *testing.T) {
 			g.OnStarEventDeleted(func(ctx context.Context, deliveryID string, eventName string, event *github.StarEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_status.go
+++ b/githubevents/events_status.go
@@ -86,8 +86,13 @@ func (g *EventHandler) handleStatusEventAny(ctx context.Context, deliveryID stri
 	eg := new(errgroup.Group)
 	for _, h := range g.onStatusEvent[StatusEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_status_test.go
+++ b/githubevents/events_status_test.go
@@ -115,6 +115,7 @@ func TestHandleStatusEventAny(t *testing.T) {
 		eventName  string
 		event      *github.StatusEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -146,6 +147,19 @@ func TestHandleStatusEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "status",
+
+				event: &github.StatusEvent{},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -162,6 +176,9 @@ func TestHandleStatusEventAny(t *testing.T) {
 			g.OnStatusEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.StatusEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_team.go
+++ b/githubevents/events_team.go
@@ -115,8 +115,13 @@ func (g *EventHandler) handleTeamEventCreated(ctx context.Context, deliveryID st
 		if _, ok := g.onTeamEvent[action]; ok {
 			for _, h := range g.onTeamEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -196,8 +201,13 @@ func (g *EventHandler) handleTeamEventDeleted(ctx context.Context, deliveryID st
 		if _, ok := g.onTeamEvent[action]; ok {
 			for _, h := range g.onTeamEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -277,8 +287,13 @@ func (g *EventHandler) handleTeamEventEdited(ctx context.Context, deliveryID str
 		if _, ok := g.onTeamEvent[action]; ok {
 			for _, h := range g.onTeamEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -358,8 +373,13 @@ func (g *EventHandler) handleTeamEventAddedToRepository(ctx context.Context, del
 		if _, ok := g.onTeamEvent[action]; ok {
 			for _, h := range g.onTeamEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -439,8 +459,13 @@ func (g *EventHandler) handleTeamEventRemovedFromRepository(ctx context.Context,
 		if _, ok := g.onTeamEvent[action]; ok {
 			for _, h := range g.onTeamEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -511,8 +536,13 @@ func (g *EventHandler) handleTeamEventAny(ctx context.Context, deliveryID string
 	eg := new(errgroup.Group)
 	for _, h := range g.onTeamEvent[TeamEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_team_add.go
+++ b/githubevents/events_team_add.go
@@ -86,8 +86,13 @@ func (g *EventHandler) handleTeamAddEventAny(ctx context.Context, deliveryID str
 	eg := new(errgroup.Group)
 	for _, h := range g.onTeamAddEvent[TeamAddEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_team_add_test.go
+++ b/githubevents/events_team_add_test.go
@@ -115,6 +115,7 @@ func TestHandleTeamAddEventAny(t *testing.T) {
 		eventName  string
 		event      *github.TeamAddEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -146,6 +147,19 @@ func TestHandleTeamAddEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "team_add",
+
+				event: &github.TeamAddEvent{},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -162,6 +176,9 @@ func TestHandleTeamAddEventAny(t *testing.T) {
 			g.OnTeamAddEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.TeamAddEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_team_test.go
+++ b/githubevents/events_team_test.go
@@ -117,6 +117,7 @@ func TestHandleTeamEventAny(t *testing.T) {
 		eventName  string
 		event      *github.TeamEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandleTeamEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "team",
+
+				event: &github.TeamEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandleTeamEventAny(t *testing.T) {
 			g.OnTeamEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.TeamEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandleTeamEventCreated(t *testing.T) {
 		eventName  string
 		event      *github.TeamEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandleTeamEventCreated(t *testing.T) {
 				eventName:  "team",
 				event:      &github.TeamEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "team",
+				event:      &github.TeamEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandleTeamEventCreated(t *testing.T) {
 			g.OnTeamEventCreated(func(ctx context.Context, deliveryID string, eventName string, event *github.TeamEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandleTeamEventDeleted(t *testing.T) {
 		eventName  string
 		event      *github.TeamEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandleTeamEventDeleted(t *testing.T) {
 				eventName:  "team",
 				event:      &github.TeamEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "team",
+				event:      &github.TeamEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandleTeamEventDeleted(t *testing.T) {
 			g.OnTeamEventDeleted(func(ctx context.Context, deliveryID string, eventName string, event *github.TeamEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -652,6 +699,7 @@ func TestHandleTeamEventEdited(t *testing.T) {
 		eventName  string
 		event      *github.TeamEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -675,6 +723,17 @@ func TestHandleTeamEventEdited(t *testing.T) {
 				eventName:  "team",
 				event:      &github.TeamEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "team",
+				event:      &github.TeamEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -725,6 +784,9 @@ func TestHandleTeamEventEdited(t *testing.T) {
 			g.OnTeamEventEdited(func(ctx context.Context, deliveryID string, eventName string, event *github.TeamEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -839,6 +901,7 @@ func TestHandleTeamEventAddedToRepository(t *testing.T) {
 		eventName  string
 		event      *github.TeamEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -862,6 +925,17 @@ func TestHandleTeamEventAddedToRepository(t *testing.T) {
 				eventName:  "team",
 				event:      &github.TeamEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "team",
+				event:      &github.TeamEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -912,6 +986,9 @@ func TestHandleTeamEventAddedToRepository(t *testing.T) {
 			g.OnTeamEventAddedToRepository(func(ctx context.Context, deliveryID string, eventName string, event *github.TeamEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -1026,6 +1103,7 @@ func TestHandleTeamEventRemovedFromRepository(t *testing.T) {
 		eventName  string
 		event      *github.TeamEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -1049,6 +1127,17 @@ func TestHandleTeamEventRemovedFromRepository(t *testing.T) {
 				eventName:  "team",
 				event:      &github.TeamEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "team",
+				event:      &github.TeamEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -1099,6 +1188,9 @@ func TestHandleTeamEventRemovedFromRepository(t *testing.T) {
 			g.OnTeamEventRemovedFromRepository(func(ctx context.Context, deliveryID string, eventName string, event *github.TeamEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_watch.go
+++ b/githubevents/events_watch.go
@@ -86,8 +86,13 @@ func (g *EventHandler) handleWatchEventAny(ctx context.Context, deliveryID strin
 	eg := new(errgroup.Group)
 	for _, h := range g.onWatchEvent[WatchEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_watch_test.go
+++ b/githubevents/events_watch_test.go
@@ -115,6 +115,7 @@ func TestHandleWatchEventAny(t *testing.T) {
 		eventName  string
 		event      *github.WatchEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -146,6 +147,19 @@ func TestHandleWatchEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "watch",
+
+				event: &github.WatchEvent{},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -162,6 +176,9 @@ func TestHandleWatchEventAny(t *testing.T) {
 			g.OnWatchEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.WatchEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_workflow_dispatch.go
+++ b/githubevents/events_workflow_dispatch.go
@@ -86,8 +86,13 @@ func (g *EventHandler) handleWorkflowDispatchEventAny(ctx context.Context, deliv
 	eg := new(errgroup.Group)
 	for _, h := range g.onWorkflowDispatchEvent[WorkflowDispatchEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_workflow_dispatch_test.go
+++ b/githubevents/events_workflow_dispatch_test.go
@@ -115,6 +115,7 @@ func TestHandleWorkflowDispatchEventAny(t *testing.T) {
 		eventName  string
 		event      *github.WorkflowDispatchEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -146,6 +147,19 @@ func TestHandleWorkflowDispatchEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "workflow_dispatch",
+
+				event: &github.WorkflowDispatchEvent{},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -162,6 +176,9 @@ func TestHandleWorkflowDispatchEventAny(t *testing.T) {
 			g.OnWorkflowDispatchEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.WorkflowDispatchEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_workflow_job.go
+++ b/githubevents/events_workflow_job.go
@@ -107,8 +107,13 @@ func (g *EventHandler) handleWorkflowJobEventQueued(ctx context.Context, deliver
 		if _, ok := g.onWorkflowJobEvent[action]; ok {
 			for _, h := range g.onWorkflowJobEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -188,8 +193,13 @@ func (g *EventHandler) handleWorkflowJobEventInProgress(ctx context.Context, del
 		if _, ok := g.onWorkflowJobEvent[action]; ok {
 			for _, h := range g.onWorkflowJobEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -269,8 +279,13 @@ func (g *EventHandler) handleWorkflowJobEventCompleted(ctx context.Context, deli
 		if _, ok := g.onWorkflowJobEvent[action]; ok {
 			for _, h := range g.onWorkflowJobEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -341,8 +356,13 @@ func (g *EventHandler) handleWorkflowJobEventAny(ctx context.Context, deliveryID
 	eg := new(errgroup.Group)
 	for _, h := range g.onWorkflowJobEvent[WorkflowJobEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_workflow_job_test.go
+++ b/githubevents/events_workflow_job_test.go
@@ -117,6 +117,7 @@ func TestHandleWorkflowJobEventAny(t *testing.T) {
 		eventName  string
 		event      *github.WorkflowJobEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandleWorkflowJobEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "workflow_job",
+
+				event: &github.WorkflowJobEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandleWorkflowJobEventAny(t *testing.T) {
 			g.OnWorkflowJobEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.WorkflowJobEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandleWorkflowJobEventQueued(t *testing.T) {
 		eventName  string
 		event      *github.WorkflowJobEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandleWorkflowJobEventQueued(t *testing.T) {
 				eventName:  "workflow_job",
 				event:      &github.WorkflowJobEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "workflow_job",
+				event:      &github.WorkflowJobEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandleWorkflowJobEventQueued(t *testing.T) {
 			g.OnWorkflowJobEventQueued(func(ctx context.Context, deliveryID string, eventName string, event *github.WorkflowJobEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandleWorkflowJobEventInProgress(t *testing.T) {
 		eventName  string
 		event      *github.WorkflowJobEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandleWorkflowJobEventInProgress(t *testing.T) {
 				eventName:  "workflow_job",
 				event:      &github.WorkflowJobEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "workflow_job",
+				event:      &github.WorkflowJobEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandleWorkflowJobEventInProgress(t *testing.T) {
 			g.OnWorkflowJobEventInProgress(func(ctx context.Context, deliveryID string, eventName string, event *github.WorkflowJobEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -652,6 +699,7 @@ func TestHandleWorkflowJobEventCompleted(t *testing.T) {
 		eventName  string
 		event      *github.WorkflowJobEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -675,6 +723,17 @@ func TestHandleWorkflowJobEventCompleted(t *testing.T) {
 				eventName:  "workflow_job",
 				event:      &github.WorkflowJobEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "workflow_job",
+				event:      &github.WorkflowJobEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -725,6 +784,9 @@ func TestHandleWorkflowJobEventCompleted(t *testing.T) {
 			g.OnWorkflowJobEventCompleted(func(ctx context.Context, deliveryID string, eventName string, event *github.WorkflowJobEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})

--- a/githubevents/events_workflow_run.go
+++ b/githubevents/events_workflow_run.go
@@ -103,8 +103,13 @@ func (g *EventHandler) handleWorkflowRunEventRequested(ctx context.Context, deli
 		if _, ok := g.onWorkflowRunEvent[action]; ok {
 			for _, h := range g.onWorkflowRunEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -184,8 +189,13 @@ func (g *EventHandler) handleWorkflowRunEventCompleted(ctx context.Context, deli
 		if _, ok := g.onWorkflowRunEvent[action]; ok {
 			for _, h := range g.onWorkflowRunEvent[action] {
 				handle := h
-				eg.Go(func() error {
-					err := handle(ctx, deliveryID, eventName, event)
+				eg.Go(func() (err error) {
+					defer func() {
+						if r := recover(); r != nil {
+							err = fmt.Errorf("recovered from panic: %v", r)
+						}
+					}()
+					err = handle(ctx, deliveryID, eventName, event)
 					if err != nil {
 						return err
 					}
@@ -256,8 +266,13 @@ func (g *EventHandler) handleWorkflowRunEventAny(ctx context.Context, deliveryID
 	eg := new(errgroup.Group)
 	for _, h := range g.onWorkflowRunEvent[WorkflowRunEventAnyAction] {
 		handle := h
-		eg.Go(func() error {
-			err := handle(ctx, deliveryID, eventName, event)
+		eg.Go(func() (err error) {
+			defer func() {
+				if r := recover(); r != nil {
+					err = fmt.Errorf("recovered from panic: %v", r)
+				}
+			}()
+			err = handle(ctx, deliveryID, eventName, event)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events_workflow_run_test.go
+++ b/githubevents/events_workflow_run_test.go
@@ -117,6 +117,7 @@ func TestHandleWorkflowRunEventAny(t *testing.T) {
 		eventName  string
 		event      *github.WorkflowRunEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -148,6 +149,19 @@ func TestHandleWorkflowRunEventAny(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "workflow_run",
+
+				event: &github.WorkflowRunEvent{Action: &action},
+
+				fail:  false,
+				panic: true,
+			},
+			wantErr: true,
+		},
+		{
 			name: "must fail event nil",
 			args: args{
 				deliveryID: "42",
@@ -164,6 +178,9 @@ func TestHandleWorkflowRunEventAny(t *testing.T) {
 			g.OnWorkflowRunEventAny(func(ctx context.Context, deliveryID string, eventName string, event *github.WorkflowRunEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -278,6 +295,7 @@ func TestHandleWorkflowRunEventRequested(t *testing.T) {
 		eventName  string
 		event      *github.WorkflowRunEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -301,6 +319,17 @@ func TestHandleWorkflowRunEventRequested(t *testing.T) {
 				eventName:  "workflow_run",
 				event:      &github.WorkflowRunEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "workflow_run",
+				event:      &github.WorkflowRunEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -351,6 +380,9 @@ func TestHandleWorkflowRunEventRequested(t *testing.T) {
 			g.OnWorkflowRunEventRequested(func(ctx context.Context, deliveryID string, eventName string, event *github.WorkflowRunEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})
@@ -465,6 +497,7 @@ func TestHandleWorkflowRunEventCompleted(t *testing.T) {
 		eventName  string
 		event      *github.WorkflowRunEvent
 		fail       bool
+		panic      bool
 	}
 	tests := []struct {
 		name    string
@@ -488,6 +521,17 @@ func TestHandleWorkflowRunEventCompleted(t *testing.T) {
 				eventName:  "workflow_run",
 				event:      &github.WorkflowRunEvent{Action: &action},
 				fail:       true,
+			},
+			wantErr: true,
+		},
+		{
+			name: "must fail with error on panic recover",
+			args: args{
+				deliveryID: "42",
+				eventName:  "workflow_run",
+				event:      &github.WorkflowRunEvent{Action: &action},
+				fail:       false,
+				panic:      true,
 			},
 			wantErr: true,
 		},
@@ -538,6 +582,9 @@ func TestHandleWorkflowRunEventCompleted(t *testing.T) {
 			g.OnWorkflowRunEventCompleted(func(ctx context.Context, deliveryID string, eventName string, event *github.WorkflowRunEvent) error {
 				if tt.args.fail {
 					return errors.New("fake error")
+				}
+				if tt.args.panic {
+					panic("fake panic")
 				}
 				return nil
 			})


### PR DESCRIPTION
x/sync/errgroup does not currently propagate recovers, see https://github.com/golang/go/issues/53757

Hey @cbrgm, this pull request will prevent the event handler from crashing on panic. It cannot be patch on around the handler because of how errgroup works.

So this PR simply adds a recover on top of each handler et set a panic recovered error