### PR TITLE
fix(error): properly forward the source error on error handler

### DIFF
--- a/gen/template_webhook_event.go.tmpl
+++ b/gen/template_webhook_event.go.tmpl
@@ -221,12 +221,12 @@ func (g *EventHandler) SetOnError(callbacks ...ErrorEventHandleFunc) {
 	g.onErrorAny[EventAnyAction] = callbacks
 }
 
-func (g *EventHandler) handleError(ctx context.Context, deliveryID string, eventName string, event interface{}, err error) error {
+func (g *EventHandler) handleError(ctx context.Context, deliveryID string, eventName string, event interface{}, srcErr error) error {
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
 	if _, ok := g.onErrorAny[EventAnyAction]; !ok {
-		return err
+		return srcErr
 	}
 	eg := new(errgroup.Group)
 	for _, h := range g.onErrorAny[EventAnyAction] {
@@ -237,7 +237,7 @@ func (g *EventHandler) handleError(ctx context.Context, deliveryID string, event
 					err = fmt.Errorf("recovered from panic: %v", r)
 				}
 			}()
-			err = handle(ctx, deliveryID, eventName, event, err)
+			err = handle(ctx, deliveryID, eventName, event, srcErr)
 			if err != nil {
 				return err
 			}

--- a/githubevents/events.go
+++ b/githubevents/events.go
@@ -269,12 +269,12 @@ func (g *EventHandler) SetOnError(callbacks ...ErrorEventHandleFunc) {
 	g.onErrorAny[EventAnyAction] = callbacks
 }
 
-func (g *EventHandler) handleError(ctx context.Context, deliveryID string, eventName string, event interface{}, err error) error {
+func (g *EventHandler) handleError(ctx context.Context, deliveryID string, eventName string, event interface{}, srcErr error) error {
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
 	if _, ok := g.onErrorAny[EventAnyAction]; !ok {
-		return err
+		return srcErr
 	}
 	eg := new(errgroup.Group)
 	for _, h := range g.onErrorAny[EventAnyAction] {
@@ -285,7 +285,7 @@ func (g *EventHandler) handleError(ctx context.Context, deliveryID string, event
 					err = fmt.Errorf("recovered from panic: %v", r)
 				}
 			}()
-			err = handle(ctx, deliveryID, eventName, event, err)
+			err = handle(ctx, deliveryID, eventName, event, srcErr)
 			if err != nil {
 				return err
 			}


### PR DESCRIPTION
<!-- PLEASE READ BEFORE DELETING

Before proceeding, ensure your pull request is targeting the main branch. Clearly describe the purpose of your pull request and the issue it addresses, if applicable. We also encourage you to read our contributing guidelines for a smoother contribution process:

  https://github.com/cbrgm/githubevents/blob/main/CONTRIBUTING.md

Thank you for your contribution!

-->

The previous fix to handle panics introduced an error on the handleError which would forward the nil named error instead of the original one because they shared the same name.

This fixes that issue and the error is properly passed down.

Maybe a test should be created to cover that issue.
