### PR TITLE
refactor(github): isolate go-github behind compat alias package

### DIFF
--- a/gen/template_webhook_event.go.tmpl
+++ b/gen/template_webhook_event.go.tmpl
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 	"net/http"
 	"sync"

--- a/gen/template_webhook_event_tests.go.tmpl
+++ b/gen/template_webhook_event_tests.go.tmpl
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"testing"
 	"sync"
 )

--- a/gen/template_webhook_event_types.go.tmpl
+++ b/gen/template_webhook_event_types.go.tmpl
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubcompat/github.go
+++ b/githubcompat/github.go
@@ -1,0 +1,95 @@
+// Copyright 2022 The GithubEvents Authors. All rights reserved.
+// Use of this source code is governed by the MIT License
+// that can be found in the LICENSE file.
+
+// Package githubcompat is the single point at which this module pins to a
+// specific major version of github.com/google/go-github. The rest of the
+// repository imports the symbols it needs through this package so that a
+// future major-version bump of go-github only requires updating the import
+// path below (assuming the upstream type and function names remain stable).
+//
+// This package is intentionally kept tiny: it only re-exports the function
+// values and event types that the generated webhook handlers reference. All
+// re-exports use Go type aliases (type X = gogithub.X) so external users that
+// already import go-github directly can keep passing *github.<Event> values
+// from go-github into this library's callbacks without any wrapping.
+//
+// External callers normally do not need to reference githubcompat: they keep
+// importing github.com/google/go-github/.../github directly for their own
+// types. The package is exported so consumers can opt into the same pinned
+// alias if they want to avoid hard-coding a specific go-github major version.
+package githubcompat
+
+import (
+	gogithub "github.com/google/go-github/v85/github"
+)
+
+// Webhook helper functions re-exported from go-github. These are plain
+// function values so the call sites in generated code (e.g.
+// github.ValidatePayload(...)) remain unchanged.
+var (
+	ValidatePayload = gogithub.ValidatePayload
+	ParseWebHook    = gogithub.ParseWebHook
+	WebHookType     = gogithub.WebHookType
+	DeliveryID      = gogithub.DeliveryID
+)
+
+// Event type aliases. These MUST be Go type aliases (type X = Y) rather than
+// new named types so that *gogithub.IssueCommentEvent and
+// *githubcompat.IssueCommentEvent are the exact same type, allowing callbacks
+// declared with go-github's types to satisfy this library's HandleFunc types.
+//
+// The list mirrors the GithubWebhooks.Event values in gen/template_params.go.
+type (
+	BranchProtectionRuleEvent         = gogithub.BranchProtectionRuleEvent
+	CheckRunEvent                     = gogithub.CheckRunEvent
+	CheckSuiteEvent                   = gogithub.CheckSuiteEvent
+	CommitCommentEvent                = gogithub.CommitCommentEvent
+	CreateEvent                       = gogithub.CreateEvent
+	CustomPropertyEvent               = gogithub.CustomPropertyEvent
+	CustomPropertyValuesEvent         = gogithub.CustomPropertyValuesEvent
+	DeleteEvent                       = gogithub.DeleteEvent
+	DeployKeyEvent                    = gogithub.DeployKeyEvent
+	DeploymentEvent                   = gogithub.DeploymentEvent
+	DeploymentStatusEvent             = gogithub.DeploymentStatusEvent
+	DiscussionEvent                   = gogithub.DiscussionEvent
+	ForkEvent                         = gogithub.ForkEvent
+	GitHubAppAuthorizationEvent       = gogithub.GitHubAppAuthorizationEvent
+	GollumEvent                       = gogithub.GollumEvent
+	InstallationEvent                 = gogithub.InstallationEvent
+	InstallationRepositoriesEvent     = gogithub.InstallationRepositoriesEvent
+	IssueCommentEvent                 = gogithub.IssueCommentEvent
+	IssuesEvent                       = gogithub.IssuesEvent
+	LabelEvent                        = gogithub.LabelEvent
+	MarketplacePurchaseEvent          = gogithub.MarketplacePurchaseEvent
+	MemberEvent                       = gogithub.MemberEvent
+	MembershipEvent                   = gogithub.MembershipEvent
+	MergeGroupEvent                   = gogithub.MergeGroupEvent
+	MetaEvent                         = gogithub.MetaEvent
+	MilestoneEvent                    = gogithub.MilestoneEvent
+	OrganizationEvent                 = gogithub.OrganizationEvent
+	OrgBlockEvent                     = gogithub.OrgBlockEvent
+	PackageEvent                      = gogithub.PackageEvent
+	PageBuildEvent                    = gogithub.PageBuildEvent
+	PingEvent                         = gogithub.PingEvent
+	ProjectV2Event                    = gogithub.ProjectV2Event
+	ProjectV2ItemEvent                = gogithub.ProjectV2ItemEvent
+	PublicEvent                       = gogithub.PublicEvent
+	PullRequestEvent                  = gogithub.PullRequestEvent
+	PullRequestReviewEvent            = gogithub.PullRequestReviewEvent
+	PullRequestReviewCommentEvent     = gogithub.PullRequestReviewCommentEvent
+	PushEvent                         = gogithub.PushEvent
+	ReleaseEvent                      = gogithub.ReleaseEvent
+	RepositoryDispatchEvent           = gogithub.RepositoryDispatchEvent
+	RepositoryRulesetEvent            = gogithub.RepositoryRulesetEvent
+	RepositoryEvent                   = gogithub.RepositoryEvent
+	RepositoryVulnerabilityAlertEvent = gogithub.RepositoryVulnerabilityAlertEvent
+	StarEvent                         = gogithub.StarEvent
+	StatusEvent                       = gogithub.StatusEvent
+	TeamEvent                         = gogithub.TeamEvent
+	TeamAddEvent                      = gogithub.TeamAddEvent
+	WatchEvent                        = gogithub.WatchEvent
+	WorkflowJobEvent                  = gogithub.WorkflowJobEvent
+	WorkflowDispatchEvent             = gogithub.WorkflowDispatchEvent
+	WorkflowRunEvent                  = gogithub.WorkflowRunEvent
+)

--- a/githubevents/events.go
+++ b/githubevents/events.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 	"net/http"
 	"sync"

--- a/githubevents/events_branch_protection_rule.go
+++ b/githubevents/events_branch_protection_rule.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_branch_protection_rule_test.go
+++ b/githubevents/events_branch_protection_rule_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_check_run.go
+++ b/githubevents/events_check_run.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_check_run_test.go
+++ b/githubevents/events_check_run_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_check_suite.go
+++ b/githubevents/events_check_suite.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_check_suite_test.go
+++ b/githubevents/events_check_suite_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_commit_comment.go
+++ b/githubevents/events_commit_comment.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_commit_comment_test.go
+++ b/githubevents/events_commit_comment_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_create.go
+++ b/githubevents/events_create.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_create_test.go
+++ b/githubevents/events_create_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_custom_property.go
+++ b/githubevents/events_custom_property.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_custom_property_test.go
+++ b/githubevents/events_custom_property_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_custom_property_values.go
+++ b/githubevents/events_custom_property_values.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_custom_property_values_test.go
+++ b/githubevents/events_custom_property_values_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_delete.go
+++ b/githubevents/events_delete.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_delete_test.go
+++ b/githubevents/events_delete_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_deploy_key.go
+++ b/githubevents/events_deploy_key.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_deploy_key_test.go
+++ b/githubevents/events_deploy_key_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_deployment.go
+++ b/githubevents/events_deployment.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_deployment_status.go
+++ b/githubevents/events_deployment_status.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_deployment_status_test.go
+++ b/githubevents/events_deployment_status_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_deployment_test.go
+++ b/githubevents/events_deployment_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_discussion.go
+++ b/githubevents/events_discussion.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_discussion_test.go
+++ b/githubevents/events_discussion_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_fork.go
+++ b/githubevents/events_fork.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_fork_test.go
+++ b/githubevents/events_fork_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_github_app_authorization.go
+++ b/githubevents/events_github_app_authorization.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_github_app_authorization_test.go
+++ b/githubevents/events_github_app_authorization_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_gollum.go
+++ b/githubevents/events_gollum.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_gollum_test.go
+++ b/githubevents/events_gollum_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_installation.go
+++ b/githubevents/events_installation.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_installation_repositories.go
+++ b/githubevents/events_installation_repositories.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_installation_repositories_test.go
+++ b/githubevents/events_installation_repositories_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_installation_test.go
+++ b/githubevents/events_installation_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_issue_comment.go
+++ b/githubevents/events_issue_comment.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_issue_comment_test.go
+++ b/githubevents/events_issue_comment_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_issues.go
+++ b/githubevents/events_issues.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_issues_test.go
+++ b/githubevents/events_issues_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_label.go
+++ b/githubevents/events_label.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_label_test.go
+++ b/githubevents/events_label_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_marketplace_purchase.go
+++ b/githubevents/events_marketplace_purchase.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_marketplace_purchase_test.go
+++ b/githubevents/events_marketplace_purchase_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_member.go
+++ b/githubevents/events_member.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_member_test.go
+++ b/githubevents/events_member_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_membership.go
+++ b/githubevents/events_membership.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_membership_test.go
+++ b/githubevents/events_membership_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_merge_group_event.go
+++ b/githubevents/events_merge_group_event.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_merge_group_event_test.go
+++ b/githubevents/events_merge_group_event_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_meta.go
+++ b/githubevents/events_meta.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_meta_test.go
+++ b/githubevents/events_meta_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_milestone.go
+++ b/githubevents/events_milestone.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_milestone_test.go
+++ b/githubevents/events_milestone_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_org_block.go
+++ b/githubevents/events_org_block.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_org_block_test.go
+++ b/githubevents/events_org_block_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_organization.go
+++ b/githubevents/events_organization.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_organization_test.go
+++ b/githubevents/events_organization_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_package.go
+++ b/githubevents/events_package.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_package_test.go
+++ b/githubevents/events_package_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_page_build.go
+++ b/githubevents/events_page_build.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_page_build_test.go
+++ b/githubevents/events_page_build_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_ping.go
+++ b/githubevents/events_ping.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_ping_test.go
+++ b/githubevents/events_ping_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_project_v2.go
+++ b/githubevents/events_project_v2.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_project_v2_item.go
+++ b/githubevents/events_project_v2_item.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_project_v2_item_test.go
+++ b/githubevents/events_project_v2_item_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_project_v2_test.go
+++ b/githubevents/events_project_v2_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_public.go
+++ b/githubevents/events_public.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_public_test.go
+++ b/githubevents/events_public_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_pull_request.go
+++ b/githubevents/events_pull_request.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_pull_request_review.go
+++ b/githubevents/events_pull_request_review.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_pull_request_review_comment.go
+++ b/githubevents/events_pull_request_review_comment.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_pull_request_review_comment_test.go
+++ b/githubevents/events_pull_request_review_comment_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_pull_request_review_test.go
+++ b/githubevents/events_pull_request_review_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_pull_request_test.go
+++ b/githubevents/events_pull_request_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_push.go
+++ b/githubevents/events_push.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_push_test.go
+++ b/githubevents/events_push_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_release.go
+++ b/githubevents/events_release.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_release_test.go
+++ b/githubevents/events_release_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_repository.go
+++ b/githubevents/events_repository.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_repository_dispatch.go
+++ b/githubevents/events_repository_dispatch.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_repository_dispatch_test.go
+++ b/githubevents/events_repository_dispatch_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_repository_ruleset.go
+++ b/githubevents/events_repository_ruleset.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_repository_ruleset_test.go
+++ b/githubevents/events_repository_ruleset_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_repository_test.go
+++ b/githubevents/events_repository_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_repository_vulnerability_alert.go
+++ b/githubevents/events_repository_vulnerability_alert.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_repository_vulnerability_alert_test.go
+++ b/githubevents/events_repository_vulnerability_alert_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_star.go
+++ b/githubevents/events_star.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_star_test.go
+++ b/githubevents/events_star_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_status.go
+++ b/githubevents/events_status.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_status_test.go
+++ b/githubevents/events_status_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_team.go
+++ b/githubevents/events_team.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_team_add.go
+++ b/githubevents/events_team_add.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_team_add_test.go
+++ b/githubevents/events_team_add_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_team_test.go
+++ b/githubevents/events_team_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_watch.go
+++ b/githubevents/events_watch.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_watch_test.go
+++ b/githubevents/events_watch_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_workflow_dispatch.go
+++ b/githubevents/events_workflow_dispatch.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_workflow_dispatch_test.go
+++ b/githubevents/events_workflow_dispatch_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_workflow_job.go
+++ b/githubevents/events_workflow_job.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_workflow_job_test.go
+++ b/githubevents/events_workflow_job_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )

--- a/githubevents/events_workflow_run.go
+++ b/githubevents/events_workflow_run.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"golang.org/x/sync/errgroup"
 )
 

--- a/githubevents/events_workflow_run_test.go
+++ b/githubevents/events_workflow_run_test.go
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v85/github"
+	github "github.com/cbrgm/githubevents/v2/githubcompat"
 	"sync"
 	"testing"
 )


### PR DESCRIPTION
Add a githubcompat package that re-exports the go-github webhook helpers and event payload types via aliases, then update  generated handlers and templates to import that package instead of the versioned go-github path directly.

This keeps existing callbacks using `github.com/google/go-github/v85/github type-compatible` while making future go-github version bumps localized to the compat package.