### PR TITLE
fix(gen): source go-github version from go.mod

### DIFF
--- a/gen/generate.go
+++ b/gen/generate.go
@@ -41,15 +41,19 @@ func main() {
 		return
 	}
 
-	out := filepath.Join(".", *outputDir)
-	err := os.MkdirAll(out, os.ModePerm)
+	imp, err := goGithubImportPath("go.mod")
 	if err != nil {
+		panic(err)
+	}
+	params.GoGithubImport = imp
+
+	out := filepath.Join(".", *outputDir)
+	if err := os.MkdirAll(out, os.ModePerm); err != nil {
 		panic("failed to create output directory")
 	}
 
 	// create events.go
-	err = ExecuteWebhookEventTemplate(filepath.Join(out, "events"), params)
-	if err != nil {
+	if err := ExecuteWebhookEventTemplate(filepath.Join(out, "events"), params); err != nil {
 		panic(err)
 	}
 
@@ -59,7 +63,8 @@ func main() {
 		fileName := "events_" + param.Name
 		outFile := filepath.Join(out, fileName)
 		err := ExecuteWebhookEventTypesTemplate(outFile, TemplateParameters{
-			Webhooks: []GithubWebhooks{param},
+			GoGithubImport: imp,
+			Webhooks:       []GithubWebhooks{param},
 		})
 		if err != nil {
 			panic(err)

--- a/gen/gomod.go
+++ b/gen/gomod.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os"
 	"regexp"
+	"sort"
 )
 
 var goGithubModuleRE = regexp.MustCompile(`github\.com/google/go-github/v\d+`)
@@ -27,6 +28,11 @@ func goGithubImportPath(gomodPath string) (string, error) {
 	case 1:
 		return matches[0] + "/github", nil
 	default:
-		return "", fmt.Errorf("multiple go-github module versions found in %s: %v", gomodPath, matches)
+		uniqueVersions := make([]string, 0, len(uniq))
+		for v := range uniq {
+			uniqueVersions = append(uniqueVersions, v)
+		}
+		sort.Strings(uniqueVersions)
+		return "", fmt.Errorf("multiple go-github module versions found in %s: %v", gomodPath, uniqueVersions)
 	}
 }

--- a/gen/gomod.go
+++ b/gen/gomod.go
@@ -1,0 +1,32 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"regexp"
+)
+
+var goGithubModuleRE = regexp.MustCompile(`github\.com/google/go-github/v\d+`)
+
+// goGithubImportPath reads gomodPath and returns the go-github package import
+// path (module path + "/github") derived from the module's require directive.
+// This keeps the go-github major version defined in exactly one place.
+func goGithubImportPath(gomodPath string) (string, error) {
+	data, err := os.ReadFile(gomodPath)
+	if err != nil {
+		return "", fmt.Errorf("read %s: %w", gomodPath, err)
+	}
+	matches := goGithubModuleRE.FindAllString(string(data), -1)
+	uniq := map[string]struct{}{}
+	for _, m := range matches {
+		uniq[m] = struct{}{}
+	}
+	switch len(uniq) {
+	case 0:
+		return "", fmt.Errorf("no github.com/google/go-github require found in %s", gomodPath)
+	case 1:
+		return matches[0] + "/github", nil
+	default:
+		return "", fmt.Errorf("multiple go-github module versions found in %s: %v", gomodPath, matches)
+	}
+}

--- a/gen/gomod_test.go
+++ b/gen/gomod_test.go
@@ -41,3 +41,18 @@ func TestGoGithubImportPathMissing(t *testing.T) {
 		t.Fatal("expected error when no go-github require present")
 	}
 }
+
+func TestGoGithubImportPathMultiple(t *testing.T) {
+	p := writeGoMod(t, `module github.com/cbrgm/githubevents/v2
+
+go 1.25.0
+
+require (
+	github.com/google/go-github/v89 v89.0.0
+	github.com/google/go-github/v90 v90.0.0
+)
+`)
+	if _, err := goGithubImportPath(p); err == nil {
+		t.Fatal("expected error when multiple distinct go-github versions present")
+	}
+}

--- a/gen/gomod_test.go
+++ b/gen/gomod_test.go
@@ -1,0 +1,43 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func writeGoMod(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	p := filepath.Join(dir, "go.mod")
+	if err := os.WriteFile(p, []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return p
+}
+
+func TestGoGithubImportPath(t *testing.T) {
+	p := writeGoMod(t, `module github.com/cbrgm/githubevents/v2
+
+go 1.25.0
+
+require (
+	github.com/google/go-github/v89 v89.0.0
+	golang.org/x/sync v0.22.0
+)
+`)
+	got, err := goGithubImportPath(p)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if want := "github.com/google/go-github/v89/github"; got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestGoGithubImportPathMissing(t *testing.T) {
+	p := writeGoMod(t, "module x\n\ngo 1.25.0\n")
+	if _, err := goGithubImportPath(p); err == nil {
+		t.Fatal("expected error when no go-github require present")
+	}
+}

--- a/gen/template_params.go
+++ b/gen/template_params.go
@@ -2,7 +2,9 @@ package main
 
 // TemplateParameters represents template parameters.
 type TemplateParameters struct {
-	Webhooks []GithubWebhooks
+	// GoGithubImport is the go-github package import path, derived from go.mod.
+	GoGithubImport string
+	Webhooks       []GithubWebhooks
 }
 
 // GithubWebhooks represents a Github webhook event type parameters.

--- a/gen/template_webhook_event.go.tmpl
+++ b/gen/template_webhook_event.go.tmpl
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v89/github"
+	"{{ .GoGithubImport }}"
 	"golang.org/x/sync/errgroup"
 	"net/http"
 	"sync"

--- a/gen/template_webhook_event_tests.go.tmpl
+++ b/gen/template_webhook_event_tests.go.tmpl
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"errors"
-	"github.com/google/go-github/v89/github"
+	"{{ .GoGithubImport }}"
 	"testing"
 	"sync"
 )

--- a/gen/template_webhook_event_types.go.tmpl
+++ b/gen/template_webhook_event_types.go.tmpl
@@ -10,7 +10,7 @@ package githubevents
 import (
 	"context"
 	"fmt"
-	"github.com/google/go-github/v89/github"
+	"{{ .GoGithubImport }}"
 	"golang.org/x/sync/errgroup"
 )
 


### PR DESCRIPTION
## What

Make the go-github version a single source of truth read from `go.mod`, instead of hardcoding it in the generator templates.

- `gen/gomod.go` parses `go.mod` and derives the go-github import path (module path + `/github`)
- the three `gen/template_*.tmpl` now use `{{ .GoGithubImport }}` instead of a baked-in `.../v89/github`

## Why

Every go-github major bump broke CI, and this is why: the version lived in three places that had to agree (`go.mod`, all 103 generated files, and the templates). Renovate bumps the first two but never the templates. CI runs `make generate` -> the still-v89 templates regenerate every file back to v89, clobbering Renovate's edits -> the code references a version that isn't vendored -> `git diff --exit-code` ("format") fails. So Renovate could *never* make a go-github major bump pass on its own, someone had to hand-edit the templates every time.

With the version coming from `go.mod`, `make generate` reproduces exactly what Renovate committed -> clean diff -> green. No more manual template edits, ever.

-> This unblocks #277 (and every future go-github bump). Once this is on `main`, I'll rebase #277 on top and it goes green with no changes.

## Testing

- `make generate && git diff --exit-code githubevents/` -> clean (byte-identical at v89, proves the derivation reproduces the committed tree)
- replayed #277's actual committed v90 tree, then `make generate` + `make format` -> **0** added churn (the format failure is gone)
- `make test` green, `go vet ./...` clean

No behavior change and no public API change, this is a generator-internals + template change only.

## Checklist
- [x] Tests added/updated (`gen/gomod_test.go` covers found / missing / multiple-version cases)
- [x] No breaking changes (generated output byte-identical, public API untouched)
- [x] Readable commit history (3 focused commits)
- [x] AI code review considered and comments resolved
