### PR TITLE
refactor(githubevents): generic dispatch helper

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -2,6 +2,7 @@ PACKAGES = $(shell go list ./...)
 GO := CGO_ENABLED=0 go
 GOFUMPT_VERSION := v0.7.0
 APIDIFF_VERSION := v0.0.0-20260811152304-ee035b5b010f
+GOFUMPT ?= gofumpt
 
 .PHONY: all
 all: build
@@ -21,11 +22,8 @@ clean:
 	rm -rf ./bin/
 
 .PHONY: format
-format: go/fmt
-
-.PHONY: go/fmt
-go/fmt:
-	$(GO) fmt $(PACKAGES)
+format:
+	$(GOFUMPT) -extra -w gen githubevents
 
 .PHONY: test
 test:
@@ -34,6 +32,7 @@ test:
 .PHONY: generate
 generate: build
 	./bin/githubhook-gen --output=githubevents
+	$(GOFUMPT) -extra -w githubevents
 
 .PHONY: build
 build: \

--- a/gen/format.go
+++ b/gen/format.go
@@ -2,19 +2,19 @@ package main
 
 import (
 	"bytes"
+	gofmt "go/format"
 	"io"
-	"os"
-	"os/exec"
 )
 
-// format formats a template using gofmt.
+// format formats a template using go/format.
 func format(in io.Reader) (io.Reader, error) {
-	var out bytes.Buffer
-
-	gofmt := exec.Command("gofmt", "-s")
-	gofmt.Stdin = in
-	gofmt.Stdout = &out
-	gofmt.Stderr = os.Stderr
-	err := gofmt.Run()
-	return &out, err
+	src, err := io.ReadAll(in)
+	if err != nil {
+		return nil, err
+	}
+	out, err := gofmt.Source(src)
+	if err != nil {
+		return nil, err
+	}
+	return bytes.NewReader(out), nil
 }

--- a/gen/template_webhook_event.go.tmpl
+++ b/gen/template_webhook_event.go.tmpl
@@ -93,29 +93,7 @@ func (g *EventHandler) handleBeforeAny(ctx context.Context, deliveryID string, e
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onBeforeAny[EventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onBeforeAny[EventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[any](ctx, deliveryID, eventName, event, g.onBeforeAny[EventAnyAction])
 }
 
 // OnAfterAny registers callbacks which are triggered after any event.
@@ -157,29 +135,7 @@ func (g *EventHandler) handleAfterAny(ctx context.Context, deliveryID string, ev
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onAfterAny[EventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onAfterAny[EventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[any](ctx, deliveryID, eventName, event, g.onAfterAny[EventAnyAction])
 }
 
 // ErrorEventHandleFunc represents a generic callback function which receives any event and an error thrown by

--- a/gen/template_webhook_event.go.tmpl
+++ b/gen/template_webhook_event.go.tmpl
@@ -52,7 +52,7 @@ func New(webhookSecret string) *EventHandler {
 }
 
 // EventHandleFunc represents a generic callback function which receives any event.
-type EventHandleFunc func(ctx context.Context, deliveryID string, eventName string, event interface{}) error
+type EventHandleFunc func(ctx context.Context, deliveryID string, eventName string, event any) error
 
 // OnBeforeAny registers callbacks which are triggered before any event.
 //
@@ -62,7 +62,7 @@ type EventHandleFunc func(ctx context.Context, deliveryID string, eventName stri
 func (g *EventHandler) OnBeforeAny(callbacks ...EventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onBeforeAny == nil {
@@ -80,7 +80,7 @@ func (g *EventHandler) OnBeforeAny(callbacks ...EventHandleFunc) {
 func (g *EventHandler) SetOnBeforeAny(callbacks ...EventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onBeforeAny == nil {
@@ -89,7 +89,7 @@ func (g *EventHandler) SetOnBeforeAny(callbacks ...EventHandleFunc) {
 	g.onBeforeAny[EventAnyAction] = callbacks
 }
 
-func (g *EventHandler) handleBeforeAny(ctx context.Context, deliveryID string, eventName string, event interface{}) error {
+func (g *EventHandler) handleBeforeAny(ctx context.Context, deliveryID string, eventName string, event any) error {
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
@@ -126,7 +126,7 @@ func (g *EventHandler) handleBeforeAny(ctx context.Context, deliveryID string, e
 func (g *EventHandler) OnAfterAny(callbacks ...EventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onAfterAny == nil {
@@ -144,7 +144,7 @@ func (g *EventHandler) OnAfterAny(callbacks ...EventHandleFunc) {
 func (g *EventHandler) SetOnAfterAny(callbacks ...EventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onAfterAny == nil {
@@ -153,7 +153,7 @@ func (g *EventHandler) SetOnAfterAny(callbacks ...EventHandleFunc) {
 	g.onAfterAny[EventAnyAction] = callbacks
 }
 
-func (g *EventHandler) handleAfterAny(ctx context.Context, deliveryID string, eventName string, event interface{}) error {
+func (g *EventHandler) handleAfterAny(ctx context.Context, deliveryID string, eventName string, event any) error {
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
@@ -184,7 +184,7 @@ func (g *EventHandler) handleAfterAny(ctx context.Context, deliveryID string, ev
 
 // ErrorEventHandleFunc represents a generic callback function which receives any event and an error thrown by
 // some function on a higher level.
-type ErrorEventHandleFunc func(ctx context.Context, deliveryID string, eventName string, event interface{}, err error) error
+type ErrorEventHandleFunc func(ctx context.Context, deliveryID string, eventName string, event any, err error) error
 
 // OnError registers callbacks which are triggered whenever an error occurs.
 //
@@ -194,7 +194,7 @@ type ErrorEventHandleFunc func(ctx context.Context, deliveryID string, eventName
 func (g *EventHandler) OnError(callbacks ...ErrorEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onErrorAny == nil {
@@ -212,7 +212,7 @@ func (g *EventHandler) OnError(callbacks ...ErrorEventHandleFunc) {
 func (g *EventHandler) SetOnError(callbacks ...ErrorEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onErrorAny == nil {
@@ -221,7 +221,7 @@ func (g *EventHandler) SetOnError(callbacks ...ErrorEventHandleFunc) {
 	g.onErrorAny[EventAnyAction] = callbacks
 }
 
-func (g *EventHandler) handleError(ctx context.Context, deliveryID string, eventName string, event interface{}, srcErr error) error {
+func (g *EventHandler) handleError(ctx context.Context, deliveryID string, eventName string, event any, srcErr error) error {
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
@@ -268,7 +268,7 @@ func (g *EventHandler) HandleEventRequest(req *http.Request) error {
 }
 
 // HandleEvent executes registered handlers.
-func (g *EventHandler) HandleEvent(ctx context.Context, deliveryID string, eventName string, event interface{}) error {
+func (g *EventHandler) HandleEvent(ctx context.Context, deliveryID string, eventName string, event any) error {
 	switch event := event.(type) {
 	{{ range $_, $webhook := .Webhooks }}
 	case *github.{{ $webhook.Event }}:

--- a/gen/template_webhook_event_types.go.tmpl
+++ b/gen/template_webhook_event_types.go.tmpl
@@ -51,7 +51,7 @@ type {{ $webhook.Event }}HandleFunc func(ctx context.Context, deliveryID string,
 func (g *EventHandler) On{{ $action.Handler }}(callbacks ...{{ $webhook.Event }}HandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.on{{ $webhook.Event }} == nil {
@@ -76,7 +76,7 @@ func (g *EventHandler) On{{ $action.Handler }}(callbacks ...{{ $webhook.Event }}
 func (g *EventHandler) SetOn{{ $action.Handler }}(callbacks ...{{ $webhook.Event }}HandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.on{{ $webhook.Event }} == nil {
@@ -139,7 +139,7 @@ func (g *EventHandler) handle{{ $action.Handler }}(ctx context.Context, delivery
 func (g *EventHandler) On{{ $webhook.Event }}Any(callbacks ...{{ $webhook.Event }}HandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.on{{ $webhook.Event }} == nil {
@@ -164,7 +164,7 @@ func (g *EventHandler) On{{ $webhook.Event }}Any(callbacks ...{{ $webhook.Event 
 func (g *EventHandler) SetOn{{ $webhook.Event }}Any(callbacks ...{{ $webhook.Event }}HandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.on{{ $webhook.Event }} == nil {

--- a/gen/template_webhook_event_types.go.tmpl
+++ b/gen/template_webhook_event_types.go.tmpl
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"{{ .GoGithubImport }}"
-	"golang.org/x/sync/errgroup"
 )
 
 {{ range $_, $webhook := .Webhooks }}
@@ -96,33 +95,10 @@ func (g *EventHandler) handle{{ $action.Handler }}(ctx context.Context, delivery
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		{{ $action.Handler }}Action,
-		{{ $webhook.Event }}AnyAction,
-	} {
-		if _, ok := g.on{{ $webhook.Event }}[action]; ok {
-			for _, h := range g.on{{ $webhook.Event }}[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.{{ $webhook.Event }}](ctx, deliveryID, eventName, event,
+		g.on{{ $webhook.Event }}[{{ $action.Handler }}Action],
+		g.on{{ $webhook.Event }}[{{ $webhook.Event }}AnyAction],
+	)
 }
 
 {{ end }}
@@ -177,29 +153,7 @@ func (g *EventHandler) handle{{ $webhook.Event }}Any(ctx context.Context, delive
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.on{{ $webhook.Event }}[{{ $webhook.Event }}AnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.on{{ $webhook.Event }}[{{ $webhook.Event }}AnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.{{ $webhook.Event }}](ctx, deliveryID, eventName, event, g.on{{ $webhook.Event }}[{{ $webhook.Event }}AnyAction])
 }
 
 // {{ $webhook.Event }} handles github.{{ $webhook.Event }}.

--- a/githubevents/dispatch.go
+++ b/githubevents/dispatch.go
@@ -1,0 +1,38 @@
+// Copyright 2022 The GithubEvents Authors. All rights reserved.
+// Use of this source code is governed by the MIT License
+// that can be found in the LICENSE file.
+
+package githubevents
+
+import (
+	"context"
+	"fmt"
+
+	"golang.org/x/sync/errgroup"
+)
+
+// dispatch runs every callback across the given groups in parallel, recovers
+// from panics as errors, and returns the first non-nil error. It is the single
+// implementation of the concurrency semantics shared by all generated handlers.
+func dispatch[T any, F ~func(ctx context.Context, deliveryID, eventName string, event T) error](
+	ctx context.Context,
+	deliveryID string,
+	eventName string,
+	event T,
+	groups ...[]F,
+) error {
+	eg := new(errgroup.Group)
+	for _, group := range groups {
+		for _, h := range group {
+			eg.Go(func() (err error) {
+				defer func() {
+					if r := recover(); r != nil {
+						err = fmt.Errorf("recovered from panic: %v", r)
+					}
+				}()
+				return h(ctx, deliveryID, eventName, event)
+			})
+		}
+	}
+	return eg.Wait()
+}

--- a/githubevents/dispatch_test.go
+++ b/githubevents/dispatch_test.go
@@ -50,8 +50,8 @@ func TestDispatchPropagatesError(t *testing.T) {
 	g.OnLabelEventCreated(func(ctx context.Context, id, name string, e *github.LabelEvent) error {
 		return want
 	})
-	if err := g.LabelEvent(context.Background(), "id", "label", labelEvent("created")); err == nil {
-		t.Fatal("want error, got nil")
+	if err := g.LabelEvent(context.Background(), "id", "label", labelEvent("created")); !errors.Is(err, want) {
+		t.Fatalf("want %v to propagate, got %v", want, err)
 	}
 }
 

--- a/githubevents/dispatch_test.go
+++ b/githubevents/dispatch_test.go
@@ -1,0 +1,81 @@
+package githubevents
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"sync/atomic"
+	"testing"
+
+	"github.com/google/go-github/v89/github"
+)
+
+func labelEvent(action string) *github.LabelEvent {
+	return &github.LabelEvent{Action: github.Ptr(action)}
+}
+
+// panic in one callback surfaces as a recovered-from-panic error.
+func TestDispatchRecoversPanic(t *testing.T) {
+	g := New("")
+	g.OnLabelEventCreated(func(ctx context.Context, id, name string, e *github.LabelEvent) error {
+		panic("boom")
+	})
+	err := g.LabelEvent(context.Background(), "id", "label", labelEvent("created"))
+	if err == nil || !strings.Contains(err.Error(), "recovered from panic:") {
+		t.Fatalf("want recovered-from-panic error, got %v", err)
+	}
+}
+
+// every registered callback runs (parallel fan-out).
+func TestDispatchRunsAll(t *testing.T) {
+	g := New("")
+	var n atomic.Int32
+	inc := func(ctx context.Context, id, name string, e *github.LabelEvent) error {
+		n.Add(1)
+		return nil
+	}
+	g.OnLabelEventCreated(inc, inc, inc)
+	if err := g.LabelEvent(context.Background(), "id", "label", labelEvent("created")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n.Load() != 3 {
+		t.Fatalf("want 3 callbacks run, got %d", n.Load())
+	}
+}
+
+// a returned error propagates.
+func TestDispatchPropagatesError(t *testing.T) {
+	g := New("")
+	want := errors.New("nope")
+	g.OnLabelEventCreated(func(ctx context.Context, id, name string, e *github.LabelEvent) error {
+		return want
+	})
+	if err := g.LabelEvent(context.Background(), "id", "label", labelEvent("created")); err == nil {
+		t.Fatal("want error, got nil")
+	}
+}
+
+// wrong / empty action is rejected by the action handler contract.
+func TestDispatchRejectsEmptyAction(t *testing.T) {
+	g := New("")
+	err := g.LabelEvent(context.Background(), "id", "label", &github.LabelEvent{})
+	if err == nil || !strings.Contains(err.Error(), "empty or nil") {
+		t.Fatalf("want empty-action error, got %v", err)
+	}
+}
+
+// the Any path (event without a matching action handler) still fans out.
+func TestDispatchAnyPath(t *testing.T) {
+	g := New("")
+	var n atomic.Int32
+	g.OnLabelEventAny(func(ctx context.Context, id, name string, e *github.LabelEvent) error {
+		n.Add(1)
+		return nil
+	})
+	if err := g.LabelEvent(context.Background(), "id", "label", labelEvent("created")); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if n.Load() != 1 {
+		t.Fatalf("want Any callback to run once, got %d", n.Load())
+	}
+}

--- a/githubevents/events.go
+++ b/githubevents/events.go
@@ -102,7 +102,7 @@ func New(webhookSecret string) *EventHandler {
 }
 
 // EventHandleFunc represents a generic callback function which receives any event.
-type EventHandleFunc func(ctx context.Context, deliveryID string, eventName string, event interface{}) error
+type EventHandleFunc func(ctx context.Context, deliveryID string, eventName string, event any) error
 
 // OnBeforeAny registers callbacks which are triggered before any event.
 //
@@ -112,7 +112,7 @@ type EventHandleFunc func(ctx context.Context, deliveryID string, eventName stri
 func (g *EventHandler) OnBeforeAny(callbacks ...EventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onBeforeAny == nil {
@@ -130,7 +130,7 @@ func (g *EventHandler) OnBeforeAny(callbacks ...EventHandleFunc) {
 func (g *EventHandler) SetOnBeforeAny(callbacks ...EventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onBeforeAny == nil {
@@ -139,7 +139,7 @@ func (g *EventHandler) SetOnBeforeAny(callbacks ...EventHandleFunc) {
 	g.onBeforeAny[EventAnyAction] = callbacks
 }
 
-func (g *EventHandler) handleBeforeAny(ctx context.Context, deliveryID string, eventName string, event interface{}) error {
+func (g *EventHandler) handleBeforeAny(ctx context.Context, deliveryID string, eventName string, event any) error {
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
@@ -176,7 +176,7 @@ func (g *EventHandler) handleBeforeAny(ctx context.Context, deliveryID string, e
 func (g *EventHandler) OnAfterAny(callbacks ...EventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onAfterAny == nil {
@@ -194,7 +194,7 @@ func (g *EventHandler) OnAfterAny(callbacks ...EventHandleFunc) {
 func (g *EventHandler) SetOnAfterAny(callbacks ...EventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onAfterAny == nil {
@@ -203,7 +203,7 @@ func (g *EventHandler) SetOnAfterAny(callbacks ...EventHandleFunc) {
 	g.onAfterAny[EventAnyAction] = callbacks
 }
 
-func (g *EventHandler) handleAfterAny(ctx context.Context, deliveryID string, eventName string, event interface{}) error {
+func (g *EventHandler) handleAfterAny(ctx context.Context, deliveryID string, eventName string, event any) error {
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
@@ -234,7 +234,7 @@ func (g *EventHandler) handleAfterAny(ctx context.Context, deliveryID string, ev
 
 // ErrorEventHandleFunc represents a generic callback function which receives any event and an error thrown by
 // some function on a higher level.
-type ErrorEventHandleFunc func(ctx context.Context, deliveryID string, eventName string, event interface{}, err error) error
+type ErrorEventHandleFunc func(ctx context.Context, deliveryID string, eventName string, event any, err error) error
 
 // OnError registers callbacks which are triggered whenever an error occurs.
 //
@@ -244,7 +244,7 @@ type ErrorEventHandleFunc func(ctx context.Context, deliveryID string, eventName
 func (g *EventHandler) OnError(callbacks ...ErrorEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onErrorAny == nil {
@@ -262,7 +262,7 @@ func (g *EventHandler) OnError(callbacks ...ErrorEventHandleFunc) {
 func (g *EventHandler) SetOnError(callbacks ...ErrorEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onErrorAny == nil {
@@ -271,7 +271,7 @@ func (g *EventHandler) SetOnError(callbacks ...ErrorEventHandleFunc) {
 	g.onErrorAny[EventAnyAction] = callbacks
 }
 
-func (g *EventHandler) handleError(ctx context.Context, deliveryID string, eventName string, event interface{}, srcErr error) error {
+func (g *EventHandler) handleError(ctx context.Context, deliveryID string, eventName string, event any, srcErr error) error {
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
@@ -318,7 +318,7 @@ func (g *EventHandler) HandleEventRequest(req *http.Request) error {
 }
 
 // HandleEvent executes registered handlers.
-func (g *EventHandler) HandleEvent(ctx context.Context, deliveryID string, eventName string, event interface{}) error {
+func (g *EventHandler) HandleEvent(ctx context.Context, deliveryID string, eventName string, event any) error {
 	switch event := event.(type) {
 
 	case *github.BranchProtectionRuleEvent:

--- a/githubevents/events.go
+++ b/githubevents/events.go
@@ -143,29 +143,7 @@ func (g *EventHandler) handleBeforeAny(ctx context.Context, deliveryID string, e
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onBeforeAny[EventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onBeforeAny[EventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[any](ctx, deliveryID, eventName, event, g.onBeforeAny[EventAnyAction])
 }
 
 // OnAfterAny registers callbacks which are triggered after any event.
@@ -207,29 +185,7 @@ func (g *EventHandler) handleAfterAny(ctx context.Context, deliveryID string, ev
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onAfterAny[EventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onAfterAny[EventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[any](ctx, deliveryID, eventName, event, g.onAfterAny[EventAnyAction])
 }
 
 // ErrorEventHandleFunc represents a generic callback function which receives any event and an error thrown by

--- a/githubevents/events_branch_protection_rule.go
+++ b/githubevents/events_branch_protection_rule.go
@@ -54,7 +54,7 @@ type BranchProtectionRuleEventHandleFunc func(ctx context.Context, deliveryID st
 func (g *EventHandler) OnBranchProtectionRuleEventCreated(callbacks ...BranchProtectionRuleEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onBranchProtectionRuleEvent == nil {
@@ -79,7 +79,7 @@ func (g *EventHandler) OnBranchProtectionRuleEventCreated(callbacks ...BranchPro
 func (g *EventHandler) SetOnBranchProtectionRuleEventCreated(callbacks ...BranchProtectionRuleEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onBranchProtectionRuleEvent == nil {
@@ -140,7 +140,7 @@ func (g *EventHandler) handleBranchProtectionRuleEventCreated(ctx context.Contex
 func (g *EventHandler) OnBranchProtectionRuleEventEdited(callbacks ...BranchProtectionRuleEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onBranchProtectionRuleEvent == nil {
@@ -165,7 +165,7 @@ func (g *EventHandler) OnBranchProtectionRuleEventEdited(callbacks ...BranchProt
 func (g *EventHandler) SetOnBranchProtectionRuleEventEdited(callbacks ...BranchProtectionRuleEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onBranchProtectionRuleEvent == nil {
@@ -226,7 +226,7 @@ func (g *EventHandler) handleBranchProtectionRuleEventEdited(ctx context.Context
 func (g *EventHandler) OnBranchProtectionRuleEventDeleted(callbacks ...BranchProtectionRuleEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onBranchProtectionRuleEvent == nil {
@@ -251,7 +251,7 @@ func (g *EventHandler) OnBranchProtectionRuleEventDeleted(callbacks ...BranchPro
 func (g *EventHandler) SetOnBranchProtectionRuleEventDeleted(callbacks ...BranchProtectionRuleEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onBranchProtectionRuleEvent == nil {
@@ -312,7 +312,7 @@ func (g *EventHandler) handleBranchProtectionRuleEventDeleted(ctx context.Contex
 func (g *EventHandler) OnBranchProtectionRuleEventAny(callbacks ...BranchProtectionRuleEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onBranchProtectionRuleEvent == nil {
@@ -337,7 +337,7 @@ func (g *EventHandler) OnBranchProtectionRuleEventAny(callbacks ...BranchProtect
 func (g *EventHandler) SetOnBranchProtectionRuleEventAny(callbacks ...BranchProtectionRuleEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onBranchProtectionRuleEvent == nil {

--- a/githubevents/events_branch_protection_rule.go
+++ b/githubevents/events_branch_protection_rule.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -99,33 +98,10 @@ func (g *EventHandler) handleBranchProtectionRuleEventCreated(ctx context.Contex
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		BranchProtectionRuleEventCreatedAction,
-		BranchProtectionRuleEventAnyAction,
-	} {
-		if _, ok := g.onBranchProtectionRuleEvent[action]; ok {
-			for _, h := range g.onBranchProtectionRuleEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.BranchProtectionRuleEvent](ctx, deliveryID, eventName, event,
+		g.onBranchProtectionRuleEvent[BranchProtectionRuleEventCreatedAction],
+		g.onBranchProtectionRuleEvent[BranchProtectionRuleEventAnyAction],
+	)
 }
 
 // OnBranchProtectionRuleEventEdited registers callbacks listening to events of type github.BranchProtectionRuleEvent and action 'edited'.
@@ -185,33 +161,10 @@ func (g *EventHandler) handleBranchProtectionRuleEventEdited(ctx context.Context
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		BranchProtectionRuleEventEditedAction,
-		BranchProtectionRuleEventAnyAction,
-	} {
-		if _, ok := g.onBranchProtectionRuleEvent[action]; ok {
-			for _, h := range g.onBranchProtectionRuleEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.BranchProtectionRuleEvent](ctx, deliveryID, eventName, event,
+		g.onBranchProtectionRuleEvent[BranchProtectionRuleEventEditedAction],
+		g.onBranchProtectionRuleEvent[BranchProtectionRuleEventAnyAction],
+	)
 }
 
 // OnBranchProtectionRuleEventDeleted registers callbacks listening to events of type github.BranchProtectionRuleEvent and action 'deleted'.
@@ -271,33 +224,10 @@ func (g *EventHandler) handleBranchProtectionRuleEventDeleted(ctx context.Contex
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		BranchProtectionRuleEventDeletedAction,
-		BranchProtectionRuleEventAnyAction,
-	} {
-		if _, ok := g.onBranchProtectionRuleEvent[action]; ok {
-			for _, h := range g.onBranchProtectionRuleEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.BranchProtectionRuleEvent](ctx, deliveryID, eventName, event,
+		g.onBranchProtectionRuleEvent[BranchProtectionRuleEventDeletedAction],
+		g.onBranchProtectionRuleEvent[BranchProtectionRuleEventAnyAction],
+	)
 }
 
 // OnBranchProtectionRuleEventAny registers callbacks listening to any events of type github.BranchProtectionRuleEvent
@@ -350,29 +280,7 @@ func (g *EventHandler) handleBranchProtectionRuleEventAny(ctx context.Context, d
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onBranchProtectionRuleEvent[BranchProtectionRuleEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onBranchProtectionRuleEvent[BranchProtectionRuleEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.BranchProtectionRuleEvent](ctx, deliveryID, eventName, event, g.onBranchProtectionRuleEvent[BranchProtectionRuleEventAnyAction])
 }
 
 // BranchProtectionRuleEvent handles github.BranchProtectionRuleEvent.

--- a/githubevents/events_check_run.go
+++ b/githubevents/events_check_run.go
@@ -58,7 +58,7 @@ type CheckRunEventHandleFunc func(ctx context.Context, deliveryID string, eventN
 func (g *EventHandler) OnCheckRunEventCreated(callbacks ...CheckRunEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCheckRunEvent == nil {
@@ -83,7 +83,7 @@ func (g *EventHandler) OnCheckRunEventCreated(callbacks ...CheckRunEventHandleFu
 func (g *EventHandler) SetOnCheckRunEventCreated(callbacks ...CheckRunEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCheckRunEvent == nil {
@@ -144,7 +144,7 @@ func (g *EventHandler) handleCheckRunEventCreated(ctx context.Context, deliveryI
 func (g *EventHandler) OnCheckRunEventCompleted(callbacks ...CheckRunEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCheckRunEvent == nil {
@@ -169,7 +169,7 @@ func (g *EventHandler) OnCheckRunEventCompleted(callbacks ...CheckRunEventHandle
 func (g *EventHandler) SetOnCheckRunEventCompleted(callbacks ...CheckRunEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCheckRunEvent == nil {
@@ -230,7 +230,7 @@ func (g *EventHandler) handleCheckRunEventCompleted(ctx context.Context, deliver
 func (g *EventHandler) OnCheckRunEventReRequested(callbacks ...CheckRunEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCheckRunEvent == nil {
@@ -255,7 +255,7 @@ func (g *EventHandler) OnCheckRunEventReRequested(callbacks ...CheckRunEventHand
 func (g *EventHandler) SetOnCheckRunEventReRequested(callbacks ...CheckRunEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCheckRunEvent == nil {
@@ -316,7 +316,7 @@ func (g *EventHandler) handleCheckRunEventReRequested(ctx context.Context, deliv
 func (g *EventHandler) OnCheckRunEventRequestAction(callbacks ...CheckRunEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCheckRunEvent == nil {
@@ -341,7 +341,7 @@ func (g *EventHandler) OnCheckRunEventRequestAction(callbacks ...CheckRunEventHa
 func (g *EventHandler) SetOnCheckRunEventRequestAction(callbacks ...CheckRunEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCheckRunEvent == nil {
@@ -402,7 +402,7 @@ func (g *EventHandler) handleCheckRunEventRequestAction(ctx context.Context, del
 func (g *EventHandler) OnCheckRunEventAny(callbacks ...CheckRunEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCheckRunEvent == nil {
@@ -427,7 +427,7 @@ func (g *EventHandler) OnCheckRunEventAny(callbacks ...CheckRunEventHandleFunc) 
 func (g *EventHandler) SetOnCheckRunEventAny(callbacks ...CheckRunEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCheckRunEvent == nil {

--- a/githubevents/events_check_run.go
+++ b/githubevents/events_check_run.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -103,33 +102,10 @@ func (g *EventHandler) handleCheckRunEventCreated(ctx context.Context, deliveryI
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		CheckRunEventCreatedAction,
-		CheckRunEventAnyAction,
-	} {
-		if _, ok := g.onCheckRunEvent[action]; ok {
-			for _, h := range g.onCheckRunEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.CheckRunEvent](ctx, deliveryID, eventName, event,
+		g.onCheckRunEvent[CheckRunEventCreatedAction],
+		g.onCheckRunEvent[CheckRunEventAnyAction],
+	)
 }
 
 // OnCheckRunEventCompleted registers callbacks listening to events of type github.CheckRunEvent and action 'completed'.
@@ -189,33 +165,10 @@ func (g *EventHandler) handleCheckRunEventCompleted(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		CheckRunEventCompletedAction,
-		CheckRunEventAnyAction,
-	} {
-		if _, ok := g.onCheckRunEvent[action]; ok {
-			for _, h := range g.onCheckRunEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.CheckRunEvent](ctx, deliveryID, eventName, event,
+		g.onCheckRunEvent[CheckRunEventCompletedAction],
+		g.onCheckRunEvent[CheckRunEventAnyAction],
+	)
 }
 
 // OnCheckRunEventReRequested registers callbacks listening to events of type github.CheckRunEvent and action 'rerequested'.
@@ -275,33 +228,10 @@ func (g *EventHandler) handleCheckRunEventReRequested(ctx context.Context, deliv
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		CheckRunEventReRequestedAction,
-		CheckRunEventAnyAction,
-	} {
-		if _, ok := g.onCheckRunEvent[action]; ok {
-			for _, h := range g.onCheckRunEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.CheckRunEvent](ctx, deliveryID, eventName, event,
+		g.onCheckRunEvent[CheckRunEventReRequestedAction],
+		g.onCheckRunEvent[CheckRunEventAnyAction],
+	)
 }
 
 // OnCheckRunEventRequestAction registers callbacks listening to events of type github.CheckRunEvent and action 'requested_action'.
@@ -361,33 +291,10 @@ func (g *EventHandler) handleCheckRunEventRequestAction(ctx context.Context, del
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		CheckRunEventRequestActionAction,
-		CheckRunEventAnyAction,
-	} {
-		if _, ok := g.onCheckRunEvent[action]; ok {
-			for _, h := range g.onCheckRunEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.CheckRunEvent](ctx, deliveryID, eventName, event,
+		g.onCheckRunEvent[CheckRunEventRequestActionAction],
+		g.onCheckRunEvent[CheckRunEventAnyAction],
+	)
 }
 
 // OnCheckRunEventAny registers callbacks listening to any events of type github.CheckRunEvent
@@ -440,29 +347,7 @@ func (g *EventHandler) handleCheckRunEventAny(ctx context.Context, deliveryID st
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onCheckRunEvent[CheckRunEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onCheckRunEvent[CheckRunEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.CheckRunEvent](ctx, deliveryID, eventName, event, g.onCheckRunEvent[CheckRunEventAnyAction])
 }
 
 // CheckRunEvent handles github.CheckRunEvent.

--- a/githubevents/events_check_suite.go
+++ b/githubevents/events_check_suite.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -99,33 +98,10 @@ func (g *EventHandler) handleCheckSuiteEventCompleted(ctx context.Context, deliv
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		CheckSuiteEventCompletedAction,
-		CheckSuiteEventAnyAction,
-	} {
-		if _, ok := g.onCheckSuiteEvent[action]; ok {
-			for _, h := range g.onCheckSuiteEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.CheckSuiteEvent](ctx, deliveryID, eventName, event,
+		g.onCheckSuiteEvent[CheckSuiteEventCompletedAction],
+		g.onCheckSuiteEvent[CheckSuiteEventAnyAction],
+	)
 }
 
 // OnCheckSuiteEventRequested registers callbacks listening to events of type github.CheckSuiteEvent and action 'requested'.
@@ -185,33 +161,10 @@ func (g *EventHandler) handleCheckSuiteEventRequested(ctx context.Context, deliv
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		CheckSuiteEventRequestedAction,
-		CheckSuiteEventAnyAction,
-	} {
-		if _, ok := g.onCheckSuiteEvent[action]; ok {
-			for _, h := range g.onCheckSuiteEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.CheckSuiteEvent](ctx, deliveryID, eventName, event,
+		g.onCheckSuiteEvent[CheckSuiteEventRequestedAction],
+		g.onCheckSuiteEvent[CheckSuiteEventAnyAction],
+	)
 }
 
 // OnCheckSuiteEventReRequested registers callbacks listening to events of type github.CheckSuiteEvent and action 'rerequested'.
@@ -271,33 +224,10 @@ func (g *EventHandler) handleCheckSuiteEventReRequested(ctx context.Context, del
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		CheckSuiteEventReRequestedAction,
-		CheckSuiteEventAnyAction,
-	} {
-		if _, ok := g.onCheckSuiteEvent[action]; ok {
-			for _, h := range g.onCheckSuiteEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.CheckSuiteEvent](ctx, deliveryID, eventName, event,
+		g.onCheckSuiteEvent[CheckSuiteEventReRequestedAction],
+		g.onCheckSuiteEvent[CheckSuiteEventAnyAction],
+	)
 }
 
 // OnCheckSuiteEventAny registers callbacks listening to any events of type github.CheckSuiteEvent
@@ -350,29 +280,7 @@ func (g *EventHandler) handleCheckSuiteEventAny(ctx context.Context, deliveryID 
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onCheckSuiteEvent[CheckSuiteEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onCheckSuiteEvent[CheckSuiteEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.CheckSuiteEvent](ctx, deliveryID, eventName, event, g.onCheckSuiteEvent[CheckSuiteEventAnyAction])
 }
 
 // CheckSuiteEvent handles github.CheckSuiteEvent.

--- a/githubevents/events_check_suite.go
+++ b/githubevents/events_check_suite.go
@@ -54,7 +54,7 @@ type CheckSuiteEventHandleFunc func(ctx context.Context, deliveryID string, even
 func (g *EventHandler) OnCheckSuiteEventCompleted(callbacks ...CheckSuiteEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCheckSuiteEvent == nil {
@@ -79,7 +79,7 @@ func (g *EventHandler) OnCheckSuiteEventCompleted(callbacks ...CheckSuiteEventHa
 func (g *EventHandler) SetOnCheckSuiteEventCompleted(callbacks ...CheckSuiteEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCheckSuiteEvent == nil {
@@ -140,7 +140,7 @@ func (g *EventHandler) handleCheckSuiteEventCompleted(ctx context.Context, deliv
 func (g *EventHandler) OnCheckSuiteEventRequested(callbacks ...CheckSuiteEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCheckSuiteEvent == nil {
@@ -165,7 +165,7 @@ func (g *EventHandler) OnCheckSuiteEventRequested(callbacks ...CheckSuiteEventHa
 func (g *EventHandler) SetOnCheckSuiteEventRequested(callbacks ...CheckSuiteEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCheckSuiteEvent == nil {
@@ -226,7 +226,7 @@ func (g *EventHandler) handleCheckSuiteEventRequested(ctx context.Context, deliv
 func (g *EventHandler) OnCheckSuiteEventReRequested(callbacks ...CheckSuiteEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCheckSuiteEvent == nil {
@@ -251,7 +251,7 @@ func (g *EventHandler) OnCheckSuiteEventReRequested(callbacks ...CheckSuiteEvent
 func (g *EventHandler) SetOnCheckSuiteEventReRequested(callbacks ...CheckSuiteEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCheckSuiteEvent == nil {
@@ -312,7 +312,7 @@ func (g *EventHandler) handleCheckSuiteEventReRequested(ctx context.Context, del
 func (g *EventHandler) OnCheckSuiteEventAny(callbacks ...CheckSuiteEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCheckSuiteEvent == nil {
@@ -337,7 +337,7 @@ func (g *EventHandler) OnCheckSuiteEventAny(callbacks ...CheckSuiteEventHandleFu
 func (g *EventHandler) SetOnCheckSuiteEventAny(callbacks ...CheckSuiteEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCheckSuiteEvent == nil {

--- a/githubevents/events_commit_comment.go
+++ b/githubevents/events_commit_comment.go
@@ -46,7 +46,7 @@ type CommitCommentEventHandleFunc func(ctx context.Context, deliveryID string, e
 func (g *EventHandler) OnCommitCommentEventCreated(callbacks ...CommitCommentEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCommitCommentEvent == nil {
@@ -71,7 +71,7 @@ func (g *EventHandler) OnCommitCommentEventCreated(callbacks ...CommitCommentEve
 func (g *EventHandler) SetOnCommitCommentEventCreated(callbacks ...CommitCommentEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCommitCommentEvent == nil {
@@ -132,7 +132,7 @@ func (g *EventHandler) handleCommitCommentEventCreated(ctx context.Context, deli
 func (g *EventHandler) OnCommitCommentEventAny(callbacks ...CommitCommentEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCommitCommentEvent == nil {
@@ -157,7 +157,7 @@ func (g *EventHandler) OnCommitCommentEventAny(callbacks ...CommitCommentEventHa
 func (g *EventHandler) SetOnCommitCommentEventAny(callbacks ...CommitCommentEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCommitCommentEvent == nil {

--- a/githubevents/events_commit_comment.go
+++ b/githubevents/events_commit_comment.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -91,33 +90,10 @@ func (g *EventHandler) handleCommitCommentEventCreated(ctx context.Context, deli
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		CommitCommentEventCreatedAction,
-		CommitCommentEventAnyAction,
-	} {
-		if _, ok := g.onCommitCommentEvent[action]; ok {
-			for _, h := range g.onCommitCommentEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.CommitCommentEvent](ctx, deliveryID, eventName, event,
+		g.onCommitCommentEvent[CommitCommentEventCreatedAction],
+		g.onCommitCommentEvent[CommitCommentEventAnyAction],
+	)
 }
 
 // OnCommitCommentEventAny registers callbacks listening to any events of type github.CommitCommentEvent
@@ -170,29 +146,7 @@ func (g *EventHandler) handleCommitCommentEventAny(ctx context.Context, delivery
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onCommitCommentEvent[CommitCommentEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onCommitCommentEvent[CommitCommentEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.CommitCommentEvent](ctx, deliveryID, eventName, event, g.onCommitCommentEvent[CommitCommentEventAnyAction])
 }
 
 // CommitCommentEvent handles github.CommitCommentEvent.

--- a/githubevents/events_create.go
+++ b/githubevents/events_create.go
@@ -42,7 +42,7 @@ type CreateEventHandleFunc func(ctx context.Context, deliveryID string, eventNam
 func (g *EventHandler) OnCreateEventAny(callbacks ...CreateEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCreateEvent == nil {
@@ -67,7 +67,7 @@ func (g *EventHandler) OnCreateEventAny(callbacks ...CreateEventHandleFunc) {
 func (g *EventHandler) SetOnCreateEventAny(callbacks ...CreateEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCreateEvent == nil {

--- a/githubevents/events_create.go
+++ b/githubevents/events_create.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -80,29 +79,7 @@ func (g *EventHandler) handleCreateEventAny(ctx context.Context, deliveryID stri
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onCreateEvent[CreateEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onCreateEvent[CreateEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.CreateEvent](ctx, deliveryID, eventName, event, g.onCreateEvent[CreateEventAnyAction])
 }
 
 // CreateEvent handles github.CreateEvent.

--- a/githubevents/events_custom_property.go
+++ b/githubevents/events_custom_property.go
@@ -58,7 +58,7 @@ type CustomPropertyEventHandleFunc func(ctx context.Context, deliveryID string, 
 func (g *EventHandler) OnCustomPropertyEventCreated(callbacks ...CustomPropertyEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCustomPropertyEvent == nil {
@@ -83,7 +83,7 @@ func (g *EventHandler) OnCustomPropertyEventCreated(callbacks ...CustomPropertyE
 func (g *EventHandler) SetOnCustomPropertyEventCreated(callbacks ...CustomPropertyEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCustomPropertyEvent == nil {
@@ -144,7 +144,7 @@ func (g *EventHandler) handleCustomPropertyEventCreated(ctx context.Context, del
 func (g *EventHandler) OnCustomPropertyDeleted(callbacks ...CustomPropertyEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCustomPropertyEvent == nil {
@@ -169,7 +169,7 @@ func (g *EventHandler) OnCustomPropertyDeleted(callbacks ...CustomPropertyEventH
 func (g *EventHandler) SetOnCustomPropertyDeleted(callbacks ...CustomPropertyEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCustomPropertyEvent == nil {
@@ -230,7 +230,7 @@ func (g *EventHandler) handleCustomPropertyDeleted(ctx context.Context, delivery
 func (g *EventHandler) OnCustomPropertyEventPromoteToEnterprise(callbacks ...CustomPropertyEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCustomPropertyEvent == nil {
@@ -255,7 +255,7 @@ func (g *EventHandler) OnCustomPropertyEventPromoteToEnterprise(callbacks ...Cus
 func (g *EventHandler) SetOnCustomPropertyEventPromoteToEnterprise(callbacks ...CustomPropertyEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCustomPropertyEvent == nil {
@@ -316,7 +316,7 @@ func (g *EventHandler) handleCustomPropertyEventPromoteToEnterprise(ctx context.
 func (g *EventHandler) OnCustomPropertyEventUpdated(callbacks ...CustomPropertyEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCustomPropertyEvent == nil {
@@ -341,7 +341,7 @@ func (g *EventHandler) OnCustomPropertyEventUpdated(callbacks ...CustomPropertyE
 func (g *EventHandler) SetOnCustomPropertyEventUpdated(callbacks ...CustomPropertyEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCustomPropertyEvent == nil {
@@ -402,7 +402,7 @@ func (g *EventHandler) handleCustomPropertyEventUpdated(ctx context.Context, del
 func (g *EventHandler) OnCustomPropertyEventAny(callbacks ...CustomPropertyEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCustomPropertyEvent == nil {
@@ -427,7 +427,7 @@ func (g *EventHandler) OnCustomPropertyEventAny(callbacks ...CustomPropertyEvent
 func (g *EventHandler) SetOnCustomPropertyEventAny(callbacks ...CustomPropertyEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCustomPropertyEvent == nil {

--- a/githubevents/events_custom_property.go
+++ b/githubevents/events_custom_property.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -103,33 +102,10 @@ func (g *EventHandler) handleCustomPropertyEventCreated(ctx context.Context, del
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		CustomPropertyEventCreatedAction,
-		CustomPropertyEventAnyAction,
-	} {
-		if _, ok := g.onCustomPropertyEvent[action]; ok {
-			for _, h := range g.onCustomPropertyEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.CustomPropertyEvent](ctx, deliveryID, eventName, event,
+		g.onCustomPropertyEvent[CustomPropertyEventCreatedAction],
+		g.onCustomPropertyEvent[CustomPropertyEventAnyAction],
+	)
 }
 
 // OnCustomPropertyDeleted registers callbacks listening to events of type github.CustomPropertyEvent and action 'deleted'.
@@ -189,33 +165,10 @@ func (g *EventHandler) handleCustomPropertyDeleted(ctx context.Context, delivery
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		CustomPropertyDeletedAction,
-		CustomPropertyEventAnyAction,
-	} {
-		if _, ok := g.onCustomPropertyEvent[action]; ok {
-			for _, h := range g.onCustomPropertyEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.CustomPropertyEvent](ctx, deliveryID, eventName, event,
+		g.onCustomPropertyEvent[CustomPropertyDeletedAction],
+		g.onCustomPropertyEvent[CustomPropertyEventAnyAction],
+	)
 }
 
 // OnCustomPropertyEventPromoteToEnterprise registers callbacks listening to events of type github.CustomPropertyEvent and action 'promote_to_enterprise'.
@@ -275,33 +228,10 @@ func (g *EventHandler) handleCustomPropertyEventPromoteToEnterprise(ctx context.
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		CustomPropertyEventPromoteToEnterpriseAction,
-		CustomPropertyEventAnyAction,
-	} {
-		if _, ok := g.onCustomPropertyEvent[action]; ok {
-			for _, h := range g.onCustomPropertyEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.CustomPropertyEvent](ctx, deliveryID, eventName, event,
+		g.onCustomPropertyEvent[CustomPropertyEventPromoteToEnterpriseAction],
+		g.onCustomPropertyEvent[CustomPropertyEventAnyAction],
+	)
 }
 
 // OnCustomPropertyEventUpdated registers callbacks listening to events of type github.CustomPropertyEvent and action 'updated'.
@@ -361,33 +291,10 @@ func (g *EventHandler) handleCustomPropertyEventUpdated(ctx context.Context, del
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		CustomPropertyEventUpdatedAction,
-		CustomPropertyEventAnyAction,
-	} {
-		if _, ok := g.onCustomPropertyEvent[action]; ok {
-			for _, h := range g.onCustomPropertyEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.CustomPropertyEvent](ctx, deliveryID, eventName, event,
+		g.onCustomPropertyEvent[CustomPropertyEventUpdatedAction],
+		g.onCustomPropertyEvent[CustomPropertyEventAnyAction],
+	)
 }
 
 // OnCustomPropertyEventAny registers callbacks listening to any events of type github.CustomPropertyEvent
@@ -440,29 +347,7 @@ func (g *EventHandler) handleCustomPropertyEventAny(ctx context.Context, deliver
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onCustomPropertyEvent[CustomPropertyEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onCustomPropertyEvent[CustomPropertyEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.CustomPropertyEvent](ctx, deliveryID, eventName, event, g.onCustomPropertyEvent[CustomPropertyEventAnyAction])
 }
 
 // CustomPropertyEvent handles github.CustomPropertyEvent.

--- a/githubevents/events_custom_property_values.go
+++ b/githubevents/events_custom_property_values.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -91,33 +90,10 @@ func (g *EventHandler) handleCustomPropertyValuesEventUpdated(ctx context.Contex
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		CustomPropertyValuesEventUpdatedAction,
-		CustomPropertyValuesEventAnyAction,
-	} {
-		if _, ok := g.onCustomPropertyValuesEvent[action]; ok {
-			for _, h := range g.onCustomPropertyValuesEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.CustomPropertyValuesEvent](ctx, deliveryID, eventName, event,
+		g.onCustomPropertyValuesEvent[CustomPropertyValuesEventUpdatedAction],
+		g.onCustomPropertyValuesEvent[CustomPropertyValuesEventAnyAction],
+	)
 }
 
 // OnCustomPropertyValuesEventAny registers callbacks listening to any events of type github.CustomPropertyValuesEvent
@@ -170,29 +146,7 @@ func (g *EventHandler) handleCustomPropertyValuesEventAny(ctx context.Context, d
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onCustomPropertyValuesEvent[CustomPropertyValuesEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onCustomPropertyValuesEvent[CustomPropertyValuesEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.CustomPropertyValuesEvent](ctx, deliveryID, eventName, event, g.onCustomPropertyValuesEvent[CustomPropertyValuesEventAnyAction])
 }
 
 // CustomPropertyValuesEvent handles github.CustomPropertyValuesEvent.

--- a/githubevents/events_custom_property_values.go
+++ b/githubevents/events_custom_property_values.go
@@ -46,7 +46,7 @@ type CustomPropertyValuesEventHandleFunc func(ctx context.Context, deliveryID st
 func (g *EventHandler) OnCustomPropertyValuesEventUpdated(callbacks ...CustomPropertyValuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCustomPropertyValuesEvent == nil {
@@ -71,7 +71,7 @@ func (g *EventHandler) OnCustomPropertyValuesEventUpdated(callbacks ...CustomPro
 func (g *EventHandler) SetOnCustomPropertyValuesEventUpdated(callbacks ...CustomPropertyValuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCustomPropertyValuesEvent == nil {
@@ -132,7 +132,7 @@ func (g *EventHandler) handleCustomPropertyValuesEventUpdated(ctx context.Contex
 func (g *EventHandler) OnCustomPropertyValuesEventAny(callbacks ...CustomPropertyValuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCustomPropertyValuesEvent == nil {
@@ -157,7 +157,7 @@ func (g *EventHandler) OnCustomPropertyValuesEventAny(callbacks ...CustomPropert
 func (g *EventHandler) SetOnCustomPropertyValuesEventAny(callbacks ...CustomPropertyValuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onCustomPropertyValuesEvent == nil {

--- a/githubevents/events_delete.go
+++ b/githubevents/events_delete.go
@@ -42,7 +42,7 @@ type DeleteEventHandleFunc func(ctx context.Context, deliveryID string, eventNam
 func (g *EventHandler) OnDeleteEventAny(callbacks ...DeleteEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDeleteEvent == nil {
@@ -67,7 +67,7 @@ func (g *EventHandler) OnDeleteEventAny(callbacks ...DeleteEventHandleFunc) {
 func (g *EventHandler) SetOnDeleteEventAny(callbacks ...DeleteEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDeleteEvent == nil {

--- a/githubevents/events_delete.go
+++ b/githubevents/events_delete.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -80,29 +79,7 @@ func (g *EventHandler) handleDeleteEventAny(ctx context.Context, deliveryID stri
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onDeleteEvent[DeleteEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onDeleteEvent[DeleteEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.DeleteEvent](ctx, deliveryID, eventName, event, g.onDeleteEvent[DeleteEventAnyAction])
 }
 
 // DeleteEvent handles github.DeleteEvent.

--- a/githubevents/events_deploy_key.go
+++ b/githubevents/events_deploy_key.go
@@ -50,7 +50,7 @@ type DeployKeyEventHandleFunc func(ctx context.Context, deliveryID string, event
 func (g *EventHandler) OnDeployKeyEventCreated(callbacks ...DeployKeyEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDeployKeyEvent == nil {
@@ -75,7 +75,7 @@ func (g *EventHandler) OnDeployKeyEventCreated(callbacks ...DeployKeyEventHandle
 func (g *EventHandler) SetOnDeployKeyEventCreated(callbacks ...DeployKeyEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDeployKeyEvent == nil {
@@ -136,7 +136,7 @@ func (g *EventHandler) handleDeployKeyEventCreated(ctx context.Context, delivery
 func (g *EventHandler) OnDeployKeyEventDeleted(callbacks ...DeployKeyEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDeployKeyEvent == nil {
@@ -161,7 +161,7 @@ func (g *EventHandler) OnDeployKeyEventDeleted(callbacks ...DeployKeyEventHandle
 func (g *EventHandler) SetOnDeployKeyEventDeleted(callbacks ...DeployKeyEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDeployKeyEvent == nil {
@@ -222,7 +222,7 @@ func (g *EventHandler) handleDeployKeyEventDeleted(ctx context.Context, delivery
 func (g *EventHandler) OnDeployKeyEventAny(callbacks ...DeployKeyEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDeployKeyEvent == nil {
@@ -247,7 +247,7 @@ func (g *EventHandler) OnDeployKeyEventAny(callbacks ...DeployKeyEventHandleFunc
 func (g *EventHandler) SetOnDeployKeyEventAny(callbacks ...DeployKeyEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDeployKeyEvent == nil {

--- a/githubevents/events_deploy_key.go
+++ b/githubevents/events_deploy_key.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -95,33 +94,10 @@ func (g *EventHandler) handleDeployKeyEventCreated(ctx context.Context, delivery
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		DeployKeyEventCreatedAction,
-		DeployKeyEventAnyAction,
-	} {
-		if _, ok := g.onDeployKeyEvent[action]; ok {
-			for _, h := range g.onDeployKeyEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.DeployKeyEvent](ctx, deliveryID, eventName, event,
+		g.onDeployKeyEvent[DeployKeyEventCreatedAction],
+		g.onDeployKeyEvent[DeployKeyEventAnyAction],
+	)
 }
 
 // OnDeployKeyEventDeleted registers callbacks listening to events of type github.DeployKeyEvent and action 'deleted'.
@@ -181,33 +157,10 @@ func (g *EventHandler) handleDeployKeyEventDeleted(ctx context.Context, delivery
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		DeployKeyEventDeletedAction,
-		DeployKeyEventAnyAction,
-	} {
-		if _, ok := g.onDeployKeyEvent[action]; ok {
-			for _, h := range g.onDeployKeyEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.DeployKeyEvent](ctx, deliveryID, eventName, event,
+		g.onDeployKeyEvent[DeployKeyEventDeletedAction],
+		g.onDeployKeyEvent[DeployKeyEventAnyAction],
+	)
 }
 
 // OnDeployKeyEventAny registers callbacks listening to any events of type github.DeployKeyEvent
@@ -260,29 +213,7 @@ func (g *EventHandler) handleDeployKeyEventAny(ctx context.Context, deliveryID s
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onDeployKeyEvent[DeployKeyEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onDeployKeyEvent[DeployKeyEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.DeployKeyEvent](ctx, deliveryID, eventName, event, g.onDeployKeyEvent[DeployKeyEventAnyAction])
 }
 
 // DeployKeyEvent handles github.DeployKeyEvent.

--- a/githubevents/events_deployment.go
+++ b/githubevents/events_deployment.go
@@ -42,7 +42,7 @@ type DeploymentEventHandleFunc func(ctx context.Context, deliveryID string, even
 func (g *EventHandler) OnDeploymentEventAny(callbacks ...DeploymentEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDeploymentEvent == nil {
@@ -67,7 +67,7 @@ func (g *EventHandler) OnDeploymentEventAny(callbacks ...DeploymentEventHandleFu
 func (g *EventHandler) SetOnDeploymentEventAny(callbacks ...DeploymentEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDeploymentEvent == nil {

--- a/githubevents/events_deployment.go
+++ b/githubevents/events_deployment.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -80,29 +79,7 @@ func (g *EventHandler) handleDeploymentEventAny(ctx context.Context, deliveryID 
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onDeploymentEvent[DeploymentEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onDeploymentEvent[DeploymentEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.DeploymentEvent](ctx, deliveryID, eventName, event, g.onDeploymentEvent[DeploymentEventAnyAction])
 }
 
 // DeploymentEvent handles github.DeploymentEvent.

--- a/githubevents/events_deployment_status.go
+++ b/githubevents/events_deployment_status.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -80,29 +79,7 @@ func (g *EventHandler) handleDeploymentStatusEventAny(ctx context.Context, deliv
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onDeploymentStatusEvent[DeploymentStatusEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onDeploymentStatusEvent[DeploymentStatusEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.DeploymentStatusEvent](ctx, deliveryID, eventName, event, g.onDeploymentStatusEvent[DeploymentStatusEventAnyAction])
 }
 
 // DeploymentStatusEvent handles github.DeploymentStatusEvent.

--- a/githubevents/events_deployment_status.go
+++ b/githubevents/events_deployment_status.go
@@ -42,7 +42,7 @@ type DeploymentStatusEventHandleFunc func(ctx context.Context, deliveryID string
 func (g *EventHandler) OnDeploymentStatusEventAny(callbacks ...DeploymentStatusEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDeploymentStatusEvent == nil {
@@ -67,7 +67,7 @@ func (g *EventHandler) OnDeploymentStatusEventAny(callbacks ...DeploymentStatusE
 func (g *EventHandler) SetOnDeploymentStatusEventAny(callbacks ...DeploymentStatusEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDeploymentStatusEvent == nil {

--- a/githubevents/events_discussion.go
+++ b/githubevents/events_discussion.go
@@ -94,7 +94,7 @@ type DiscussionEventHandleFunc func(ctx context.Context, deliveryID string, even
 func (g *EventHandler) OnDiscussionEventCreated(callbacks ...DiscussionEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDiscussionEvent == nil {
@@ -119,7 +119,7 @@ func (g *EventHandler) OnDiscussionEventCreated(callbacks ...DiscussionEventHand
 func (g *EventHandler) SetOnDiscussionEventCreated(callbacks ...DiscussionEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDiscussionEvent == nil {
@@ -180,7 +180,7 @@ func (g *EventHandler) handleDiscussionEventCreated(ctx context.Context, deliver
 func (g *EventHandler) OnDiscussionEventEdited(callbacks ...DiscussionEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDiscussionEvent == nil {
@@ -205,7 +205,7 @@ func (g *EventHandler) OnDiscussionEventEdited(callbacks ...DiscussionEventHandl
 func (g *EventHandler) SetOnDiscussionEventEdited(callbacks ...DiscussionEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDiscussionEvent == nil {
@@ -266,7 +266,7 @@ func (g *EventHandler) handleDiscussionEventEdited(ctx context.Context, delivery
 func (g *EventHandler) OnDiscussionEventDeleted(callbacks ...DiscussionEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDiscussionEvent == nil {
@@ -291,7 +291,7 @@ func (g *EventHandler) OnDiscussionEventDeleted(callbacks ...DiscussionEventHand
 func (g *EventHandler) SetOnDiscussionEventDeleted(callbacks ...DiscussionEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDiscussionEvent == nil {
@@ -352,7 +352,7 @@ func (g *EventHandler) handleDiscussionEventDeleted(ctx context.Context, deliver
 func (g *EventHandler) OnDiscussionEventPinned(callbacks ...DiscussionEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDiscussionEvent == nil {
@@ -377,7 +377,7 @@ func (g *EventHandler) OnDiscussionEventPinned(callbacks ...DiscussionEventHandl
 func (g *EventHandler) SetOnDiscussionEventPinned(callbacks ...DiscussionEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDiscussionEvent == nil {
@@ -438,7 +438,7 @@ func (g *EventHandler) handleDiscussionEventPinned(ctx context.Context, delivery
 func (g *EventHandler) OnDiscussionEventUnpinned(callbacks ...DiscussionEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDiscussionEvent == nil {
@@ -463,7 +463,7 @@ func (g *EventHandler) OnDiscussionEventUnpinned(callbacks ...DiscussionEventHan
 func (g *EventHandler) SetOnDiscussionEventUnpinned(callbacks ...DiscussionEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDiscussionEvent == nil {
@@ -524,7 +524,7 @@ func (g *EventHandler) handleDiscussionEventUnpinned(ctx context.Context, delive
 func (g *EventHandler) OnDiscussionEventLocked(callbacks ...DiscussionEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDiscussionEvent == nil {
@@ -549,7 +549,7 @@ func (g *EventHandler) OnDiscussionEventLocked(callbacks ...DiscussionEventHandl
 func (g *EventHandler) SetOnDiscussionEventLocked(callbacks ...DiscussionEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDiscussionEvent == nil {
@@ -610,7 +610,7 @@ func (g *EventHandler) handleDiscussionEventLocked(ctx context.Context, delivery
 func (g *EventHandler) OnDiscussionEventUnlocked(callbacks ...DiscussionEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDiscussionEvent == nil {
@@ -635,7 +635,7 @@ func (g *EventHandler) OnDiscussionEventUnlocked(callbacks ...DiscussionEventHan
 func (g *EventHandler) SetOnDiscussionEventUnlocked(callbacks ...DiscussionEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDiscussionEvent == nil {
@@ -696,7 +696,7 @@ func (g *EventHandler) handleDiscussionEventUnlocked(ctx context.Context, delive
 func (g *EventHandler) OnDiscussionEventTransferred(callbacks ...DiscussionEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDiscussionEvent == nil {
@@ -721,7 +721,7 @@ func (g *EventHandler) OnDiscussionEventTransferred(callbacks ...DiscussionEvent
 func (g *EventHandler) SetOnDiscussionEventTransferred(callbacks ...DiscussionEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDiscussionEvent == nil {
@@ -782,7 +782,7 @@ func (g *EventHandler) handleDiscussionEventTransferred(ctx context.Context, del
 func (g *EventHandler) OnDiscussionEventCategoryChanged(callbacks ...DiscussionEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDiscussionEvent == nil {
@@ -807,7 +807,7 @@ func (g *EventHandler) OnDiscussionEventCategoryChanged(callbacks ...DiscussionE
 func (g *EventHandler) SetOnDiscussionEventCategoryChanged(callbacks ...DiscussionEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDiscussionEvent == nil {
@@ -868,7 +868,7 @@ func (g *EventHandler) handleDiscussionEventCategoryChanged(ctx context.Context,
 func (g *EventHandler) OnDiscussionEventAnswered(callbacks ...DiscussionEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDiscussionEvent == nil {
@@ -893,7 +893,7 @@ func (g *EventHandler) OnDiscussionEventAnswered(callbacks ...DiscussionEventHan
 func (g *EventHandler) SetOnDiscussionEventAnswered(callbacks ...DiscussionEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDiscussionEvent == nil {
@@ -954,7 +954,7 @@ func (g *EventHandler) handleDiscussionEventAnswered(ctx context.Context, delive
 func (g *EventHandler) OnDiscussionEventUnanswered(callbacks ...DiscussionEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDiscussionEvent == nil {
@@ -979,7 +979,7 @@ func (g *EventHandler) OnDiscussionEventUnanswered(callbacks ...DiscussionEventH
 func (g *EventHandler) SetOnDiscussionEventUnanswered(callbacks ...DiscussionEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDiscussionEvent == nil {
@@ -1040,7 +1040,7 @@ func (g *EventHandler) handleDiscussionEventUnanswered(ctx context.Context, deli
 func (g *EventHandler) OnDiscussionEventLabeled(callbacks ...DiscussionEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDiscussionEvent == nil {
@@ -1065,7 +1065,7 @@ func (g *EventHandler) OnDiscussionEventLabeled(callbacks ...DiscussionEventHand
 func (g *EventHandler) SetOnDiscussionEventLabeled(callbacks ...DiscussionEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDiscussionEvent == nil {
@@ -1126,7 +1126,7 @@ func (g *EventHandler) handleDiscussionEventLabeled(ctx context.Context, deliver
 func (g *EventHandler) OnDiscussionEventUnlabeled(callbacks ...DiscussionEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDiscussionEvent == nil {
@@ -1151,7 +1151,7 @@ func (g *EventHandler) OnDiscussionEventUnlabeled(callbacks ...DiscussionEventHa
 func (g *EventHandler) SetOnDiscussionEventUnlabeled(callbacks ...DiscussionEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDiscussionEvent == nil {
@@ -1212,7 +1212,7 @@ func (g *EventHandler) handleDiscussionEventUnlabeled(ctx context.Context, deliv
 func (g *EventHandler) OnDiscussionEventAny(callbacks ...DiscussionEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDiscussionEvent == nil {
@@ -1237,7 +1237,7 @@ func (g *EventHandler) OnDiscussionEventAny(callbacks ...DiscussionEventHandleFu
 func (g *EventHandler) SetOnDiscussionEventAny(callbacks ...DiscussionEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onDiscussionEvent == nil {

--- a/githubevents/events_discussion.go
+++ b/githubevents/events_discussion.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -139,33 +138,10 @@ func (g *EventHandler) handleDiscussionEventCreated(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		DiscussionEventCreatedAction,
-		DiscussionEventAnyAction,
-	} {
-		if _, ok := g.onDiscussionEvent[action]; ok {
-			for _, h := range g.onDiscussionEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event,
+		g.onDiscussionEvent[DiscussionEventCreatedAction],
+		g.onDiscussionEvent[DiscussionEventAnyAction],
+	)
 }
 
 // OnDiscussionEventEdited registers callbacks listening to events of type github.DiscussionEvent and action 'edited'.
@@ -225,33 +201,10 @@ func (g *EventHandler) handleDiscussionEventEdited(ctx context.Context, delivery
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		DiscussionEventEditedAction,
-		DiscussionEventAnyAction,
-	} {
-		if _, ok := g.onDiscussionEvent[action]; ok {
-			for _, h := range g.onDiscussionEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event,
+		g.onDiscussionEvent[DiscussionEventEditedAction],
+		g.onDiscussionEvent[DiscussionEventAnyAction],
+	)
 }
 
 // OnDiscussionEventDeleted registers callbacks listening to events of type github.DiscussionEvent and action 'deleted'.
@@ -311,33 +264,10 @@ func (g *EventHandler) handleDiscussionEventDeleted(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		DiscussionEventDeletedAction,
-		DiscussionEventAnyAction,
-	} {
-		if _, ok := g.onDiscussionEvent[action]; ok {
-			for _, h := range g.onDiscussionEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event,
+		g.onDiscussionEvent[DiscussionEventDeletedAction],
+		g.onDiscussionEvent[DiscussionEventAnyAction],
+	)
 }
 
 // OnDiscussionEventPinned registers callbacks listening to events of type github.DiscussionEvent and action 'pinned'.
@@ -397,33 +327,10 @@ func (g *EventHandler) handleDiscussionEventPinned(ctx context.Context, delivery
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		DiscussionEventPinnedAction,
-		DiscussionEventAnyAction,
-	} {
-		if _, ok := g.onDiscussionEvent[action]; ok {
-			for _, h := range g.onDiscussionEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event,
+		g.onDiscussionEvent[DiscussionEventPinnedAction],
+		g.onDiscussionEvent[DiscussionEventAnyAction],
+	)
 }
 
 // OnDiscussionEventUnpinned registers callbacks listening to events of type github.DiscussionEvent and action 'unpinned'.
@@ -483,33 +390,10 @@ func (g *EventHandler) handleDiscussionEventUnpinned(ctx context.Context, delive
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		DiscussionEventUnpinnedAction,
-		DiscussionEventAnyAction,
-	} {
-		if _, ok := g.onDiscussionEvent[action]; ok {
-			for _, h := range g.onDiscussionEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event,
+		g.onDiscussionEvent[DiscussionEventUnpinnedAction],
+		g.onDiscussionEvent[DiscussionEventAnyAction],
+	)
 }
 
 // OnDiscussionEventLocked registers callbacks listening to events of type github.DiscussionEvent and action 'locked'.
@@ -569,33 +453,10 @@ func (g *EventHandler) handleDiscussionEventLocked(ctx context.Context, delivery
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		DiscussionEventLockedAction,
-		DiscussionEventAnyAction,
-	} {
-		if _, ok := g.onDiscussionEvent[action]; ok {
-			for _, h := range g.onDiscussionEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event,
+		g.onDiscussionEvent[DiscussionEventLockedAction],
+		g.onDiscussionEvent[DiscussionEventAnyAction],
+	)
 }
 
 // OnDiscussionEventUnlocked registers callbacks listening to events of type github.DiscussionEvent and action 'unlocked'.
@@ -655,33 +516,10 @@ func (g *EventHandler) handleDiscussionEventUnlocked(ctx context.Context, delive
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		DiscussionEventUnlockedAction,
-		DiscussionEventAnyAction,
-	} {
-		if _, ok := g.onDiscussionEvent[action]; ok {
-			for _, h := range g.onDiscussionEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event,
+		g.onDiscussionEvent[DiscussionEventUnlockedAction],
+		g.onDiscussionEvent[DiscussionEventAnyAction],
+	)
 }
 
 // OnDiscussionEventTransferred registers callbacks listening to events of type github.DiscussionEvent and action 'transferred'.
@@ -741,33 +579,10 @@ func (g *EventHandler) handleDiscussionEventTransferred(ctx context.Context, del
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		DiscussionEventTransferredAction,
-		DiscussionEventAnyAction,
-	} {
-		if _, ok := g.onDiscussionEvent[action]; ok {
-			for _, h := range g.onDiscussionEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event,
+		g.onDiscussionEvent[DiscussionEventTransferredAction],
+		g.onDiscussionEvent[DiscussionEventAnyAction],
+	)
 }
 
 // OnDiscussionEventCategoryChanged registers callbacks listening to events of type github.DiscussionEvent and action 'category_changed'.
@@ -827,33 +642,10 @@ func (g *EventHandler) handleDiscussionEventCategoryChanged(ctx context.Context,
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		DiscussionEventCategoryChangedAction,
-		DiscussionEventAnyAction,
-	} {
-		if _, ok := g.onDiscussionEvent[action]; ok {
-			for _, h := range g.onDiscussionEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event,
+		g.onDiscussionEvent[DiscussionEventCategoryChangedAction],
+		g.onDiscussionEvent[DiscussionEventAnyAction],
+	)
 }
 
 // OnDiscussionEventAnswered registers callbacks listening to events of type github.DiscussionEvent and action 'answered'.
@@ -913,33 +705,10 @@ func (g *EventHandler) handleDiscussionEventAnswered(ctx context.Context, delive
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		DiscussionEventAnsweredAction,
-		DiscussionEventAnyAction,
-	} {
-		if _, ok := g.onDiscussionEvent[action]; ok {
-			for _, h := range g.onDiscussionEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event,
+		g.onDiscussionEvent[DiscussionEventAnsweredAction],
+		g.onDiscussionEvent[DiscussionEventAnyAction],
+	)
 }
 
 // OnDiscussionEventUnanswered registers callbacks listening to events of type github.DiscussionEvent and action 'unanswered'.
@@ -999,33 +768,10 @@ func (g *EventHandler) handleDiscussionEventUnanswered(ctx context.Context, deli
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		DiscussionEventUnansweredAction,
-		DiscussionEventAnyAction,
-	} {
-		if _, ok := g.onDiscussionEvent[action]; ok {
-			for _, h := range g.onDiscussionEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event,
+		g.onDiscussionEvent[DiscussionEventUnansweredAction],
+		g.onDiscussionEvent[DiscussionEventAnyAction],
+	)
 }
 
 // OnDiscussionEventLabeled registers callbacks listening to events of type github.DiscussionEvent and action 'labeled'.
@@ -1085,33 +831,10 @@ func (g *EventHandler) handleDiscussionEventLabeled(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		DiscussionEventLabeledAction,
-		DiscussionEventAnyAction,
-	} {
-		if _, ok := g.onDiscussionEvent[action]; ok {
-			for _, h := range g.onDiscussionEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event,
+		g.onDiscussionEvent[DiscussionEventLabeledAction],
+		g.onDiscussionEvent[DiscussionEventAnyAction],
+	)
 }
 
 // OnDiscussionEventUnlabeled registers callbacks listening to events of type github.DiscussionEvent and action 'unlabeled'.
@@ -1171,33 +894,10 @@ func (g *EventHandler) handleDiscussionEventUnlabeled(ctx context.Context, deliv
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		DiscussionEventUnlabeledAction,
-		DiscussionEventAnyAction,
-	} {
-		if _, ok := g.onDiscussionEvent[action]; ok {
-			for _, h := range g.onDiscussionEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event,
+		g.onDiscussionEvent[DiscussionEventUnlabeledAction],
+		g.onDiscussionEvent[DiscussionEventAnyAction],
+	)
 }
 
 // OnDiscussionEventAny registers callbacks listening to any events of type github.DiscussionEvent
@@ -1250,29 +950,7 @@ func (g *EventHandler) handleDiscussionEventAny(ctx context.Context, deliveryID 
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onDiscussionEvent[DiscussionEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onDiscussionEvent[DiscussionEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event, g.onDiscussionEvent[DiscussionEventAnyAction])
 }
 
 // DiscussionEvent handles github.DiscussionEvent.

--- a/githubevents/events_fork.go
+++ b/githubevents/events_fork.go
@@ -42,7 +42,7 @@ type ForkEventHandleFunc func(ctx context.Context, deliveryID string, eventName 
 func (g *EventHandler) OnForkEventAny(callbacks ...ForkEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onForkEvent == nil {
@@ -67,7 +67,7 @@ func (g *EventHandler) OnForkEventAny(callbacks ...ForkEventHandleFunc) {
 func (g *EventHandler) SetOnForkEventAny(callbacks ...ForkEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onForkEvent == nil {

--- a/githubevents/events_fork.go
+++ b/githubevents/events_fork.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -80,29 +79,7 @@ func (g *EventHandler) handleForkEventAny(ctx context.Context, deliveryID string
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onForkEvent[ForkEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onForkEvent[ForkEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.ForkEvent](ctx, deliveryID, eventName, event, g.onForkEvent[ForkEventAnyAction])
 }
 
 // ForkEvent handles github.ForkEvent.

--- a/githubevents/events_github_app_authorization.go
+++ b/githubevents/events_github_app_authorization.go
@@ -46,7 +46,7 @@ type GitHubAppAuthorizationEventHandleFunc func(ctx context.Context, deliveryID 
 func (g *EventHandler) OnGitHubAppAuthorizationEventRevoked(callbacks ...GitHubAppAuthorizationEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onGitHubAppAuthorizationEvent == nil {
@@ -71,7 +71,7 @@ func (g *EventHandler) OnGitHubAppAuthorizationEventRevoked(callbacks ...GitHubA
 func (g *EventHandler) SetOnGitHubAppAuthorizationEventRevoked(callbacks ...GitHubAppAuthorizationEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onGitHubAppAuthorizationEvent == nil {
@@ -132,7 +132,7 @@ func (g *EventHandler) handleGitHubAppAuthorizationEventRevoked(ctx context.Cont
 func (g *EventHandler) OnGitHubAppAuthorizationEventAny(callbacks ...GitHubAppAuthorizationEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onGitHubAppAuthorizationEvent == nil {
@@ -157,7 +157,7 @@ func (g *EventHandler) OnGitHubAppAuthorizationEventAny(callbacks ...GitHubAppAu
 func (g *EventHandler) SetOnGitHubAppAuthorizationEventAny(callbacks ...GitHubAppAuthorizationEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onGitHubAppAuthorizationEvent == nil {

--- a/githubevents/events_github_app_authorization.go
+++ b/githubevents/events_github_app_authorization.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -91,33 +90,10 @@ func (g *EventHandler) handleGitHubAppAuthorizationEventRevoked(ctx context.Cont
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		GitHubAppAuthorizationEventRevokedAction,
-		GitHubAppAuthorizationEventAnyAction,
-	} {
-		if _, ok := g.onGitHubAppAuthorizationEvent[action]; ok {
-			for _, h := range g.onGitHubAppAuthorizationEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.GitHubAppAuthorizationEvent](ctx, deliveryID, eventName, event,
+		g.onGitHubAppAuthorizationEvent[GitHubAppAuthorizationEventRevokedAction],
+		g.onGitHubAppAuthorizationEvent[GitHubAppAuthorizationEventAnyAction],
+	)
 }
 
 // OnGitHubAppAuthorizationEventAny registers callbacks listening to any events of type github.GitHubAppAuthorizationEvent
@@ -170,29 +146,7 @@ func (g *EventHandler) handleGitHubAppAuthorizationEventAny(ctx context.Context,
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onGitHubAppAuthorizationEvent[GitHubAppAuthorizationEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onGitHubAppAuthorizationEvent[GitHubAppAuthorizationEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.GitHubAppAuthorizationEvent](ctx, deliveryID, eventName, event, g.onGitHubAppAuthorizationEvent[GitHubAppAuthorizationEventAnyAction])
 }
 
 // GitHubAppAuthorizationEvent handles github.GitHubAppAuthorizationEvent.

--- a/githubevents/events_gollum.go
+++ b/githubevents/events_gollum.go
@@ -42,7 +42,7 @@ type GollumEventHandleFunc func(ctx context.Context, deliveryID string, eventNam
 func (g *EventHandler) OnGollumEventAny(callbacks ...GollumEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onGollumEvent == nil {
@@ -67,7 +67,7 @@ func (g *EventHandler) OnGollumEventAny(callbacks ...GollumEventHandleFunc) {
 func (g *EventHandler) SetOnGollumEventAny(callbacks ...GollumEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onGollumEvent == nil {

--- a/githubevents/events_gollum.go
+++ b/githubevents/events_gollum.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -80,29 +79,7 @@ func (g *EventHandler) handleGollumEventAny(ctx context.Context, deliveryID stri
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onGollumEvent[GollumEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onGollumEvent[GollumEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.GollumEvent](ctx, deliveryID, eventName, event, g.onGollumEvent[GollumEventAnyAction])
 }
 
 // GollumEvent handles github.GollumEvent.

--- a/githubevents/events_installation.go
+++ b/githubevents/events_installation.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -107,33 +106,10 @@ func (g *EventHandler) handleInstallationEventCreated(ctx context.Context, deliv
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		InstallationEventCreatedAction,
-		InstallationEventAnyAction,
-	} {
-		if _, ok := g.onInstallationEvent[action]; ok {
-			for _, h := range g.onInstallationEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.InstallationEvent](ctx, deliveryID, eventName, event,
+		g.onInstallationEvent[InstallationEventCreatedAction],
+		g.onInstallationEvent[InstallationEventAnyAction],
+	)
 }
 
 // OnInstallationEventDeleted registers callbacks listening to events of type github.InstallationEvent and action 'deleted'.
@@ -193,33 +169,10 @@ func (g *EventHandler) handleInstallationEventDeleted(ctx context.Context, deliv
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		InstallationEventDeletedAction,
-		InstallationEventAnyAction,
-	} {
-		if _, ok := g.onInstallationEvent[action]; ok {
-			for _, h := range g.onInstallationEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.InstallationEvent](ctx, deliveryID, eventName, event,
+		g.onInstallationEvent[InstallationEventDeletedAction],
+		g.onInstallationEvent[InstallationEventAnyAction],
+	)
 }
 
 // OnInstallationEventEventSuspend registers callbacks listening to events of type github.InstallationEvent and action 'suspend'.
@@ -279,33 +232,10 @@ func (g *EventHandler) handleInstallationEventEventSuspend(ctx context.Context, 
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		InstallationEventEventSuspendAction,
-		InstallationEventAnyAction,
-	} {
-		if _, ok := g.onInstallationEvent[action]; ok {
-			for _, h := range g.onInstallationEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.InstallationEvent](ctx, deliveryID, eventName, event,
+		g.onInstallationEvent[InstallationEventEventSuspendAction],
+		g.onInstallationEvent[InstallationEventAnyAction],
+	)
 }
 
 // OnInstallationEventEventUnsuspend registers callbacks listening to events of type github.InstallationEvent and action 'unsuspend'.
@@ -365,33 +295,10 @@ func (g *EventHandler) handleInstallationEventEventUnsuspend(ctx context.Context
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		InstallationEventEventUnsuspendAction,
-		InstallationEventAnyAction,
-	} {
-		if _, ok := g.onInstallationEvent[action]; ok {
-			for _, h := range g.onInstallationEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.InstallationEvent](ctx, deliveryID, eventName, event,
+		g.onInstallationEvent[InstallationEventEventUnsuspendAction],
+		g.onInstallationEvent[InstallationEventAnyAction],
+	)
 }
 
 // OnInstallationEventNewPermissionsAccepted registers callbacks listening to events of type github.InstallationEvent and action 'new_permissions_accepted'.
@@ -451,33 +358,10 @@ func (g *EventHandler) handleInstallationEventNewPermissionsAccepted(ctx context
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		InstallationEventNewPermissionsAcceptedAction,
-		InstallationEventAnyAction,
-	} {
-		if _, ok := g.onInstallationEvent[action]; ok {
-			for _, h := range g.onInstallationEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.InstallationEvent](ctx, deliveryID, eventName, event,
+		g.onInstallationEvent[InstallationEventNewPermissionsAcceptedAction],
+		g.onInstallationEvent[InstallationEventAnyAction],
+	)
 }
 
 // OnInstallationEventAny registers callbacks listening to any events of type github.InstallationEvent
@@ -530,29 +414,7 @@ func (g *EventHandler) handleInstallationEventAny(ctx context.Context, deliveryI
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onInstallationEvent[InstallationEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onInstallationEvent[InstallationEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.InstallationEvent](ctx, deliveryID, eventName, event, g.onInstallationEvent[InstallationEventAnyAction])
 }
 
 // InstallationEvent handles github.InstallationEvent.

--- a/githubevents/events_installation.go
+++ b/githubevents/events_installation.go
@@ -62,7 +62,7 @@ type InstallationEventHandleFunc func(ctx context.Context, deliveryID string, ev
 func (g *EventHandler) OnInstallationEventCreated(callbacks ...InstallationEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onInstallationEvent == nil {
@@ -87,7 +87,7 @@ func (g *EventHandler) OnInstallationEventCreated(callbacks ...InstallationEvent
 func (g *EventHandler) SetOnInstallationEventCreated(callbacks ...InstallationEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onInstallationEvent == nil {
@@ -148,7 +148,7 @@ func (g *EventHandler) handleInstallationEventCreated(ctx context.Context, deliv
 func (g *EventHandler) OnInstallationEventDeleted(callbacks ...InstallationEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onInstallationEvent == nil {
@@ -173,7 +173,7 @@ func (g *EventHandler) OnInstallationEventDeleted(callbacks ...InstallationEvent
 func (g *EventHandler) SetOnInstallationEventDeleted(callbacks ...InstallationEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onInstallationEvent == nil {
@@ -234,7 +234,7 @@ func (g *EventHandler) handleInstallationEventDeleted(ctx context.Context, deliv
 func (g *EventHandler) OnInstallationEventEventSuspend(callbacks ...InstallationEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onInstallationEvent == nil {
@@ -259,7 +259,7 @@ func (g *EventHandler) OnInstallationEventEventSuspend(callbacks ...Installation
 func (g *EventHandler) SetOnInstallationEventEventSuspend(callbacks ...InstallationEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onInstallationEvent == nil {
@@ -320,7 +320,7 @@ func (g *EventHandler) handleInstallationEventEventSuspend(ctx context.Context, 
 func (g *EventHandler) OnInstallationEventEventUnsuspend(callbacks ...InstallationEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onInstallationEvent == nil {
@@ -345,7 +345,7 @@ func (g *EventHandler) OnInstallationEventEventUnsuspend(callbacks ...Installati
 func (g *EventHandler) SetOnInstallationEventEventUnsuspend(callbacks ...InstallationEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onInstallationEvent == nil {
@@ -406,7 +406,7 @@ func (g *EventHandler) handleInstallationEventEventUnsuspend(ctx context.Context
 func (g *EventHandler) OnInstallationEventNewPermissionsAccepted(callbacks ...InstallationEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onInstallationEvent == nil {
@@ -431,7 +431,7 @@ func (g *EventHandler) OnInstallationEventNewPermissionsAccepted(callbacks ...In
 func (g *EventHandler) SetOnInstallationEventNewPermissionsAccepted(callbacks ...InstallationEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onInstallationEvent == nil {
@@ -492,7 +492,7 @@ func (g *EventHandler) handleInstallationEventNewPermissionsAccepted(ctx context
 func (g *EventHandler) OnInstallationEventAny(callbacks ...InstallationEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onInstallationEvent == nil {
@@ -517,7 +517,7 @@ func (g *EventHandler) OnInstallationEventAny(callbacks ...InstallationEventHand
 func (g *EventHandler) SetOnInstallationEventAny(callbacks ...InstallationEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onInstallationEvent == nil {

--- a/githubevents/events_installation_repositories.go
+++ b/githubevents/events_installation_repositories.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -95,33 +94,10 @@ func (g *EventHandler) handleInstallationRepositoriesEventAdded(ctx context.Cont
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		InstallationRepositoriesEventAddedAction,
-		InstallationRepositoriesEventAnyAction,
-	} {
-		if _, ok := g.onInstallationRepositoriesEvent[action]; ok {
-			for _, h := range g.onInstallationRepositoriesEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.InstallationRepositoriesEvent](ctx, deliveryID, eventName, event,
+		g.onInstallationRepositoriesEvent[InstallationRepositoriesEventAddedAction],
+		g.onInstallationRepositoriesEvent[InstallationRepositoriesEventAnyAction],
+	)
 }
 
 // OnInstallationRepositoriesEventRemoved registers callbacks listening to events of type github.InstallationRepositoriesEvent and action 'removed'.
@@ -181,33 +157,10 @@ func (g *EventHandler) handleInstallationRepositoriesEventRemoved(ctx context.Co
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		InstallationRepositoriesEventRemovedAction,
-		InstallationRepositoriesEventAnyAction,
-	} {
-		if _, ok := g.onInstallationRepositoriesEvent[action]; ok {
-			for _, h := range g.onInstallationRepositoriesEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.InstallationRepositoriesEvent](ctx, deliveryID, eventName, event,
+		g.onInstallationRepositoriesEvent[InstallationRepositoriesEventRemovedAction],
+		g.onInstallationRepositoriesEvent[InstallationRepositoriesEventAnyAction],
+	)
 }
 
 // OnInstallationRepositoriesEventAny registers callbacks listening to any events of type github.InstallationRepositoriesEvent
@@ -260,29 +213,7 @@ func (g *EventHandler) handleInstallationRepositoriesEventAny(ctx context.Contex
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onInstallationRepositoriesEvent[InstallationRepositoriesEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onInstallationRepositoriesEvent[InstallationRepositoriesEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.InstallationRepositoriesEvent](ctx, deliveryID, eventName, event, g.onInstallationRepositoriesEvent[InstallationRepositoriesEventAnyAction])
 }
 
 // InstallationRepositoriesEvent handles github.InstallationRepositoriesEvent.

--- a/githubevents/events_installation_repositories.go
+++ b/githubevents/events_installation_repositories.go
@@ -50,7 +50,7 @@ type InstallationRepositoriesEventHandleFunc func(ctx context.Context, deliveryI
 func (g *EventHandler) OnInstallationRepositoriesEventAdded(callbacks ...InstallationRepositoriesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onInstallationRepositoriesEvent == nil {
@@ -75,7 +75,7 @@ func (g *EventHandler) OnInstallationRepositoriesEventAdded(callbacks ...Install
 func (g *EventHandler) SetOnInstallationRepositoriesEventAdded(callbacks ...InstallationRepositoriesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onInstallationRepositoriesEvent == nil {
@@ -136,7 +136,7 @@ func (g *EventHandler) handleInstallationRepositoriesEventAdded(ctx context.Cont
 func (g *EventHandler) OnInstallationRepositoriesEventRemoved(callbacks ...InstallationRepositoriesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onInstallationRepositoriesEvent == nil {
@@ -161,7 +161,7 @@ func (g *EventHandler) OnInstallationRepositoriesEventRemoved(callbacks ...Insta
 func (g *EventHandler) SetOnInstallationRepositoriesEventRemoved(callbacks ...InstallationRepositoriesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onInstallationRepositoriesEvent == nil {
@@ -222,7 +222,7 @@ func (g *EventHandler) handleInstallationRepositoriesEventRemoved(ctx context.Co
 func (g *EventHandler) OnInstallationRepositoriesEventAny(callbacks ...InstallationRepositoriesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onInstallationRepositoriesEvent == nil {
@@ -247,7 +247,7 @@ func (g *EventHandler) OnInstallationRepositoriesEventAny(callbacks ...Installat
 func (g *EventHandler) SetOnInstallationRepositoriesEventAny(callbacks ...InstallationRepositoriesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onInstallationRepositoriesEvent == nil {

--- a/githubevents/events_issue_comment.go
+++ b/githubevents/events_issue_comment.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -99,33 +98,10 @@ func (g *EventHandler) handleIssueCommentCreated(ctx context.Context, deliveryID
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		IssueCommentCreatedAction,
-		IssueCommentEventAnyAction,
-	} {
-		if _, ok := g.onIssueCommentEvent[action]; ok {
-			for _, h := range g.onIssueCommentEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.IssueCommentEvent](ctx, deliveryID, eventName, event,
+		g.onIssueCommentEvent[IssueCommentCreatedAction],
+		g.onIssueCommentEvent[IssueCommentEventAnyAction],
+	)
 }
 
 // OnIssueCommentEdited registers callbacks listening to events of type github.IssueCommentEvent and action 'edited'.
@@ -185,33 +161,10 @@ func (g *EventHandler) handleIssueCommentEdited(ctx context.Context, deliveryID 
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		IssueCommentEditedAction,
-		IssueCommentEventAnyAction,
-	} {
-		if _, ok := g.onIssueCommentEvent[action]; ok {
-			for _, h := range g.onIssueCommentEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.IssueCommentEvent](ctx, deliveryID, eventName, event,
+		g.onIssueCommentEvent[IssueCommentEditedAction],
+		g.onIssueCommentEvent[IssueCommentEventAnyAction],
+	)
 }
 
 // OnIssueCommentDeleted registers callbacks listening to events of type github.IssueCommentEvent and action 'deleted'.
@@ -271,33 +224,10 @@ func (g *EventHandler) handleIssueCommentDeleted(ctx context.Context, deliveryID
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		IssueCommentDeletedAction,
-		IssueCommentEventAnyAction,
-	} {
-		if _, ok := g.onIssueCommentEvent[action]; ok {
-			for _, h := range g.onIssueCommentEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.IssueCommentEvent](ctx, deliveryID, eventName, event,
+		g.onIssueCommentEvent[IssueCommentDeletedAction],
+		g.onIssueCommentEvent[IssueCommentEventAnyAction],
+	)
 }
 
 // OnIssueCommentEventAny registers callbacks listening to any events of type github.IssueCommentEvent
@@ -350,29 +280,7 @@ func (g *EventHandler) handleIssueCommentEventAny(ctx context.Context, deliveryI
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onIssueCommentEvent[IssueCommentEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onIssueCommentEvent[IssueCommentEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.IssueCommentEvent](ctx, deliveryID, eventName, event, g.onIssueCommentEvent[IssueCommentEventAnyAction])
 }
 
 // IssueCommentEvent handles github.IssueCommentEvent.

--- a/githubevents/events_issue_comment.go
+++ b/githubevents/events_issue_comment.go
@@ -54,7 +54,7 @@ type IssueCommentEventHandleFunc func(ctx context.Context, deliveryID string, ev
 func (g *EventHandler) OnIssueCommentCreated(callbacks ...IssueCommentEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssueCommentEvent == nil {
@@ -79,7 +79,7 @@ func (g *EventHandler) OnIssueCommentCreated(callbacks ...IssueCommentEventHandl
 func (g *EventHandler) SetOnIssueCommentCreated(callbacks ...IssueCommentEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssueCommentEvent == nil {
@@ -140,7 +140,7 @@ func (g *EventHandler) handleIssueCommentCreated(ctx context.Context, deliveryID
 func (g *EventHandler) OnIssueCommentEdited(callbacks ...IssueCommentEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssueCommentEvent == nil {
@@ -165,7 +165,7 @@ func (g *EventHandler) OnIssueCommentEdited(callbacks ...IssueCommentEventHandle
 func (g *EventHandler) SetOnIssueCommentEdited(callbacks ...IssueCommentEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssueCommentEvent == nil {
@@ -226,7 +226,7 @@ func (g *EventHandler) handleIssueCommentEdited(ctx context.Context, deliveryID 
 func (g *EventHandler) OnIssueCommentDeleted(callbacks ...IssueCommentEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssueCommentEvent == nil {
@@ -251,7 +251,7 @@ func (g *EventHandler) OnIssueCommentDeleted(callbacks ...IssueCommentEventHandl
 func (g *EventHandler) SetOnIssueCommentDeleted(callbacks ...IssueCommentEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssueCommentEvent == nil {
@@ -312,7 +312,7 @@ func (g *EventHandler) handleIssueCommentDeleted(ctx context.Context, deliveryID
 func (g *EventHandler) OnIssueCommentEventAny(callbacks ...IssueCommentEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssueCommentEvent == nil {
@@ -337,7 +337,7 @@ func (g *EventHandler) OnIssueCommentEventAny(callbacks ...IssueCommentEventHand
 func (g *EventHandler) SetOnIssueCommentEventAny(callbacks ...IssueCommentEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssueCommentEvent == nil {

--- a/githubevents/events_issues.go
+++ b/githubevents/events_issues.go
@@ -106,7 +106,7 @@ type IssuesEventHandleFunc func(ctx context.Context, deliveryID string, eventNam
 func (g *EventHandler) OnIssuesEventOpened(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -131,7 +131,7 @@ func (g *EventHandler) OnIssuesEventOpened(callbacks ...IssuesEventHandleFunc) {
 func (g *EventHandler) SetOnIssuesEventOpened(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -192,7 +192,7 @@ func (g *EventHandler) handleIssuesEventOpened(ctx context.Context, deliveryID s
 func (g *EventHandler) OnIssuesEventEdited(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -217,7 +217,7 @@ func (g *EventHandler) OnIssuesEventEdited(callbacks ...IssuesEventHandleFunc) {
 func (g *EventHandler) SetOnIssuesEventEdited(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -278,7 +278,7 @@ func (g *EventHandler) handleIssuesEventEdited(ctx context.Context, deliveryID s
 func (g *EventHandler) OnIssuesEventDeleted(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -303,7 +303,7 @@ func (g *EventHandler) OnIssuesEventDeleted(callbacks ...IssuesEventHandleFunc) 
 func (g *EventHandler) SetOnIssuesEventDeleted(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -364,7 +364,7 @@ func (g *EventHandler) handleIssuesEventDeleted(ctx context.Context, deliveryID 
 func (g *EventHandler) OnIssuesEventPinned(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -389,7 +389,7 @@ func (g *EventHandler) OnIssuesEventPinned(callbacks ...IssuesEventHandleFunc) {
 func (g *EventHandler) SetOnIssuesEventPinned(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -450,7 +450,7 @@ func (g *EventHandler) handleIssuesEventPinned(ctx context.Context, deliveryID s
 func (g *EventHandler) OnIssuesEventUnpinned(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -475,7 +475,7 @@ func (g *EventHandler) OnIssuesEventUnpinned(callbacks ...IssuesEventHandleFunc)
 func (g *EventHandler) SetOnIssuesEventUnpinned(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -536,7 +536,7 @@ func (g *EventHandler) handleIssuesEventUnpinned(ctx context.Context, deliveryID
 func (g *EventHandler) OnIssuesEventClosed(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -561,7 +561,7 @@ func (g *EventHandler) OnIssuesEventClosed(callbacks ...IssuesEventHandleFunc) {
 func (g *EventHandler) SetOnIssuesEventClosed(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -622,7 +622,7 @@ func (g *EventHandler) handleIssuesEventClosed(ctx context.Context, deliveryID s
 func (g *EventHandler) OnIssuesEventReopened(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -647,7 +647,7 @@ func (g *EventHandler) OnIssuesEventReopened(callbacks ...IssuesEventHandleFunc)
 func (g *EventHandler) SetOnIssuesEventReopened(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -708,7 +708,7 @@ func (g *EventHandler) handleIssuesEventReopened(ctx context.Context, deliveryID
 func (g *EventHandler) OnIssuesEventAssigned(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -733,7 +733,7 @@ func (g *EventHandler) OnIssuesEventAssigned(callbacks ...IssuesEventHandleFunc)
 func (g *EventHandler) SetOnIssuesEventAssigned(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -794,7 +794,7 @@ func (g *EventHandler) handleIssuesEventAssigned(ctx context.Context, deliveryID
 func (g *EventHandler) OnIssuesEventUnassigned(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -819,7 +819,7 @@ func (g *EventHandler) OnIssuesEventUnassigned(callbacks ...IssuesEventHandleFun
 func (g *EventHandler) SetOnIssuesEventUnassigned(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -880,7 +880,7 @@ func (g *EventHandler) handleIssuesEventUnassigned(ctx context.Context, delivery
 func (g *EventHandler) OnIssuesEventLabeled(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -905,7 +905,7 @@ func (g *EventHandler) OnIssuesEventLabeled(callbacks ...IssuesEventHandleFunc) 
 func (g *EventHandler) SetOnIssuesEventLabeled(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -966,7 +966,7 @@ func (g *EventHandler) handleIssuesEventLabeled(ctx context.Context, deliveryID 
 func (g *EventHandler) OnIssuesEventUnlabeled(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -991,7 +991,7 @@ func (g *EventHandler) OnIssuesEventUnlabeled(callbacks ...IssuesEventHandleFunc
 func (g *EventHandler) SetOnIssuesEventUnlabeled(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -1052,7 +1052,7 @@ func (g *EventHandler) handleIssuesEventUnlabeled(ctx context.Context, deliveryI
 func (g *EventHandler) OnIssuesEventLocked(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -1077,7 +1077,7 @@ func (g *EventHandler) OnIssuesEventLocked(callbacks ...IssuesEventHandleFunc) {
 func (g *EventHandler) SetOnIssuesEventLocked(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -1138,7 +1138,7 @@ func (g *EventHandler) handleIssuesEventLocked(ctx context.Context, deliveryID s
 func (g *EventHandler) OnIssuesEventUnlocked(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -1163,7 +1163,7 @@ func (g *EventHandler) OnIssuesEventUnlocked(callbacks ...IssuesEventHandleFunc)
 func (g *EventHandler) SetOnIssuesEventUnlocked(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -1224,7 +1224,7 @@ func (g *EventHandler) handleIssuesEventUnlocked(ctx context.Context, deliveryID
 func (g *EventHandler) OnIssuesEventTransferred(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -1249,7 +1249,7 @@ func (g *EventHandler) OnIssuesEventTransferred(callbacks ...IssuesEventHandleFu
 func (g *EventHandler) SetOnIssuesEventTransferred(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -1310,7 +1310,7 @@ func (g *EventHandler) handleIssuesEventTransferred(ctx context.Context, deliver
 func (g *EventHandler) OnIssuesEventMilestoned(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -1335,7 +1335,7 @@ func (g *EventHandler) OnIssuesEventMilestoned(callbacks ...IssuesEventHandleFun
 func (g *EventHandler) SetOnIssuesEventMilestoned(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -1396,7 +1396,7 @@ func (g *EventHandler) handleIssuesEventMilestoned(ctx context.Context, delivery
 func (g *EventHandler) OnIssuesEventDeMilestoned(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -1421,7 +1421,7 @@ func (g *EventHandler) OnIssuesEventDeMilestoned(callbacks ...IssuesEventHandleF
 func (g *EventHandler) SetOnIssuesEventDeMilestoned(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -1482,7 +1482,7 @@ func (g *EventHandler) handleIssuesEventDeMilestoned(ctx context.Context, delive
 func (g *EventHandler) OnIssuesEventAny(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {
@@ -1507,7 +1507,7 @@ func (g *EventHandler) OnIssuesEventAny(callbacks ...IssuesEventHandleFunc) {
 func (g *EventHandler) SetOnIssuesEventAny(callbacks ...IssuesEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onIssuesEvent == nil {

--- a/githubevents/events_issues.go
+++ b/githubevents/events_issues.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -151,33 +150,10 @@ func (g *EventHandler) handleIssuesEventOpened(ctx context.Context, deliveryID s
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		IssuesEventOpenedAction,
-		IssuesEventAnyAction,
-	} {
-		if _, ok := g.onIssuesEvent[action]; ok {
-			for _, h := range g.onIssuesEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
+		g.onIssuesEvent[IssuesEventOpenedAction],
+		g.onIssuesEvent[IssuesEventAnyAction],
+	)
 }
 
 // OnIssuesEventEdited registers callbacks listening to events of type github.IssuesEvent and action 'edited'.
@@ -237,33 +213,10 @@ func (g *EventHandler) handleIssuesEventEdited(ctx context.Context, deliveryID s
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		IssuesEventEditedAction,
-		IssuesEventAnyAction,
-	} {
-		if _, ok := g.onIssuesEvent[action]; ok {
-			for _, h := range g.onIssuesEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
+		g.onIssuesEvent[IssuesEventEditedAction],
+		g.onIssuesEvent[IssuesEventAnyAction],
+	)
 }
 
 // OnIssuesEventDeleted registers callbacks listening to events of type github.IssuesEvent and action 'deleted'.
@@ -323,33 +276,10 @@ func (g *EventHandler) handleIssuesEventDeleted(ctx context.Context, deliveryID 
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		IssuesEventDeletedAction,
-		IssuesEventAnyAction,
-	} {
-		if _, ok := g.onIssuesEvent[action]; ok {
-			for _, h := range g.onIssuesEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
+		g.onIssuesEvent[IssuesEventDeletedAction],
+		g.onIssuesEvent[IssuesEventAnyAction],
+	)
 }
 
 // OnIssuesEventPinned registers callbacks listening to events of type github.IssuesEvent and action 'pinned'.
@@ -409,33 +339,10 @@ func (g *EventHandler) handleIssuesEventPinned(ctx context.Context, deliveryID s
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		IssuesEventPinnedAction,
-		IssuesEventAnyAction,
-	} {
-		if _, ok := g.onIssuesEvent[action]; ok {
-			for _, h := range g.onIssuesEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
+		g.onIssuesEvent[IssuesEventPinnedAction],
+		g.onIssuesEvent[IssuesEventAnyAction],
+	)
 }
 
 // OnIssuesEventUnpinned registers callbacks listening to events of type github.IssuesEvent and action 'unpinned'.
@@ -495,33 +402,10 @@ func (g *EventHandler) handleIssuesEventUnpinned(ctx context.Context, deliveryID
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		IssuesEventUnpinnedAction,
-		IssuesEventAnyAction,
-	} {
-		if _, ok := g.onIssuesEvent[action]; ok {
-			for _, h := range g.onIssuesEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
+		g.onIssuesEvent[IssuesEventUnpinnedAction],
+		g.onIssuesEvent[IssuesEventAnyAction],
+	)
 }
 
 // OnIssuesEventClosed registers callbacks listening to events of type github.IssuesEvent and action 'closed'.
@@ -581,33 +465,10 @@ func (g *EventHandler) handleIssuesEventClosed(ctx context.Context, deliveryID s
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		IssuesEventClosedAction,
-		IssuesEventAnyAction,
-	} {
-		if _, ok := g.onIssuesEvent[action]; ok {
-			for _, h := range g.onIssuesEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
+		g.onIssuesEvent[IssuesEventClosedAction],
+		g.onIssuesEvent[IssuesEventAnyAction],
+	)
 }
 
 // OnIssuesEventReopened registers callbacks listening to events of type github.IssuesEvent and action 'reopened'.
@@ -667,33 +528,10 @@ func (g *EventHandler) handleIssuesEventReopened(ctx context.Context, deliveryID
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		IssuesEventReopenedAction,
-		IssuesEventAnyAction,
-	} {
-		if _, ok := g.onIssuesEvent[action]; ok {
-			for _, h := range g.onIssuesEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
+		g.onIssuesEvent[IssuesEventReopenedAction],
+		g.onIssuesEvent[IssuesEventAnyAction],
+	)
 }
 
 // OnIssuesEventAssigned registers callbacks listening to events of type github.IssuesEvent and action 'assigned'.
@@ -753,33 +591,10 @@ func (g *EventHandler) handleIssuesEventAssigned(ctx context.Context, deliveryID
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		IssuesEventAssignedAction,
-		IssuesEventAnyAction,
-	} {
-		if _, ok := g.onIssuesEvent[action]; ok {
-			for _, h := range g.onIssuesEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
+		g.onIssuesEvent[IssuesEventAssignedAction],
+		g.onIssuesEvent[IssuesEventAnyAction],
+	)
 }
 
 // OnIssuesEventUnassigned registers callbacks listening to events of type github.IssuesEvent and action 'unassigned'.
@@ -839,33 +654,10 @@ func (g *EventHandler) handleIssuesEventUnassigned(ctx context.Context, delivery
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		IssuesEventUnassignedAction,
-		IssuesEventAnyAction,
-	} {
-		if _, ok := g.onIssuesEvent[action]; ok {
-			for _, h := range g.onIssuesEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
+		g.onIssuesEvent[IssuesEventUnassignedAction],
+		g.onIssuesEvent[IssuesEventAnyAction],
+	)
 }
 
 // OnIssuesEventLabeled registers callbacks listening to events of type github.IssuesEvent and action 'labeled'.
@@ -925,33 +717,10 @@ func (g *EventHandler) handleIssuesEventLabeled(ctx context.Context, deliveryID 
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		IssuesEventLabeledAction,
-		IssuesEventAnyAction,
-	} {
-		if _, ok := g.onIssuesEvent[action]; ok {
-			for _, h := range g.onIssuesEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
+		g.onIssuesEvent[IssuesEventLabeledAction],
+		g.onIssuesEvent[IssuesEventAnyAction],
+	)
 }
 
 // OnIssuesEventUnlabeled registers callbacks listening to events of type github.IssuesEvent and action 'unlabeled'.
@@ -1011,33 +780,10 @@ func (g *EventHandler) handleIssuesEventUnlabeled(ctx context.Context, deliveryI
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		IssuesEventUnlabeledAction,
-		IssuesEventAnyAction,
-	} {
-		if _, ok := g.onIssuesEvent[action]; ok {
-			for _, h := range g.onIssuesEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
+		g.onIssuesEvent[IssuesEventUnlabeledAction],
+		g.onIssuesEvent[IssuesEventAnyAction],
+	)
 }
 
 // OnIssuesEventLocked registers callbacks listening to events of type github.IssuesEvent and action 'locked'.
@@ -1097,33 +843,10 @@ func (g *EventHandler) handleIssuesEventLocked(ctx context.Context, deliveryID s
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		IssuesEventLockedAction,
-		IssuesEventAnyAction,
-	} {
-		if _, ok := g.onIssuesEvent[action]; ok {
-			for _, h := range g.onIssuesEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
+		g.onIssuesEvent[IssuesEventLockedAction],
+		g.onIssuesEvent[IssuesEventAnyAction],
+	)
 }
 
 // OnIssuesEventUnlocked registers callbacks listening to events of type github.IssuesEvent and action 'unlocked'.
@@ -1183,33 +906,10 @@ func (g *EventHandler) handleIssuesEventUnlocked(ctx context.Context, deliveryID
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		IssuesEventUnlockedAction,
-		IssuesEventAnyAction,
-	} {
-		if _, ok := g.onIssuesEvent[action]; ok {
-			for _, h := range g.onIssuesEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
+		g.onIssuesEvent[IssuesEventUnlockedAction],
+		g.onIssuesEvent[IssuesEventAnyAction],
+	)
 }
 
 // OnIssuesEventTransferred registers callbacks listening to events of type github.IssuesEvent and action 'transferred'.
@@ -1269,33 +969,10 @@ func (g *EventHandler) handleIssuesEventTransferred(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		IssuesEventTransferredAction,
-		IssuesEventAnyAction,
-	} {
-		if _, ok := g.onIssuesEvent[action]; ok {
-			for _, h := range g.onIssuesEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
+		g.onIssuesEvent[IssuesEventTransferredAction],
+		g.onIssuesEvent[IssuesEventAnyAction],
+	)
 }
 
 // OnIssuesEventMilestoned registers callbacks listening to events of type github.IssuesEvent and action 'milestoned'.
@@ -1355,33 +1032,10 @@ func (g *EventHandler) handleIssuesEventMilestoned(ctx context.Context, delivery
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		IssuesEventMilestonedAction,
-		IssuesEventAnyAction,
-	} {
-		if _, ok := g.onIssuesEvent[action]; ok {
-			for _, h := range g.onIssuesEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
+		g.onIssuesEvent[IssuesEventMilestonedAction],
+		g.onIssuesEvent[IssuesEventAnyAction],
+	)
 }
 
 // OnIssuesEventDeMilestoned registers callbacks listening to events of type github.IssuesEvent and action 'demilestoned'.
@@ -1441,33 +1095,10 @@ func (g *EventHandler) handleIssuesEventDeMilestoned(ctx context.Context, delive
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		IssuesEventDeMilestonedAction,
-		IssuesEventAnyAction,
-	} {
-		if _, ok := g.onIssuesEvent[action]; ok {
-			for _, h := range g.onIssuesEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
+		g.onIssuesEvent[IssuesEventDeMilestonedAction],
+		g.onIssuesEvent[IssuesEventAnyAction],
+	)
 }
 
 // OnIssuesEventAny registers callbacks listening to any events of type github.IssuesEvent
@@ -1520,29 +1151,7 @@ func (g *EventHandler) handleIssuesEventAny(ctx context.Context, deliveryID stri
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onIssuesEvent[IssuesEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onIssuesEvent[IssuesEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event, g.onIssuesEvent[IssuesEventAnyAction])
 }
 
 // IssuesEvent handles github.IssuesEvent.

--- a/githubevents/events_label.go
+++ b/githubevents/events_label.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -99,33 +98,10 @@ func (g *EventHandler) handleLabelEventCreated(ctx context.Context, deliveryID s
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		LabelEventCreatedAction,
-		LabelEventAnyAction,
-	} {
-		if _, ok := g.onLabelEvent[action]; ok {
-			for _, h := range g.onLabelEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.LabelEvent](ctx, deliveryID, eventName, event,
+		g.onLabelEvent[LabelEventCreatedAction],
+		g.onLabelEvent[LabelEventAnyAction],
+	)
 }
 
 // OnLabelEventEdited registers callbacks listening to events of type github.LabelEvent and action 'edited'.
@@ -185,33 +161,10 @@ func (g *EventHandler) handleLabelEventEdited(ctx context.Context, deliveryID st
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		LabelEventEditedAction,
-		LabelEventAnyAction,
-	} {
-		if _, ok := g.onLabelEvent[action]; ok {
-			for _, h := range g.onLabelEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.LabelEvent](ctx, deliveryID, eventName, event,
+		g.onLabelEvent[LabelEventEditedAction],
+		g.onLabelEvent[LabelEventAnyAction],
+	)
 }
 
 // OnLabelEventDeleted registers callbacks listening to events of type github.LabelEvent and action 'deleted'.
@@ -271,33 +224,10 @@ func (g *EventHandler) handleLabelEventDeleted(ctx context.Context, deliveryID s
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		LabelEventDeletedAction,
-		LabelEventAnyAction,
-	} {
-		if _, ok := g.onLabelEvent[action]; ok {
-			for _, h := range g.onLabelEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.LabelEvent](ctx, deliveryID, eventName, event,
+		g.onLabelEvent[LabelEventDeletedAction],
+		g.onLabelEvent[LabelEventAnyAction],
+	)
 }
 
 // OnLabelEventAny registers callbacks listening to any events of type github.LabelEvent
@@ -350,29 +280,7 @@ func (g *EventHandler) handleLabelEventAny(ctx context.Context, deliveryID strin
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onLabelEvent[LabelEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onLabelEvent[LabelEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.LabelEvent](ctx, deliveryID, eventName, event, g.onLabelEvent[LabelEventAnyAction])
 }
 
 // LabelEvent handles github.LabelEvent.

--- a/githubevents/events_label.go
+++ b/githubevents/events_label.go
@@ -54,7 +54,7 @@ type LabelEventHandleFunc func(ctx context.Context, deliveryID string, eventName
 func (g *EventHandler) OnLabelEventCreated(callbacks ...LabelEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onLabelEvent == nil {
@@ -79,7 +79,7 @@ func (g *EventHandler) OnLabelEventCreated(callbacks ...LabelEventHandleFunc) {
 func (g *EventHandler) SetOnLabelEventCreated(callbacks ...LabelEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onLabelEvent == nil {
@@ -140,7 +140,7 @@ func (g *EventHandler) handleLabelEventCreated(ctx context.Context, deliveryID s
 func (g *EventHandler) OnLabelEventEdited(callbacks ...LabelEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onLabelEvent == nil {
@@ -165,7 +165,7 @@ func (g *EventHandler) OnLabelEventEdited(callbacks ...LabelEventHandleFunc) {
 func (g *EventHandler) SetOnLabelEventEdited(callbacks ...LabelEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onLabelEvent == nil {
@@ -226,7 +226,7 @@ func (g *EventHandler) handleLabelEventEdited(ctx context.Context, deliveryID st
 func (g *EventHandler) OnLabelEventDeleted(callbacks ...LabelEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onLabelEvent == nil {
@@ -251,7 +251,7 @@ func (g *EventHandler) OnLabelEventDeleted(callbacks ...LabelEventHandleFunc) {
 func (g *EventHandler) SetOnLabelEventDeleted(callbacks ...LabelEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onLabelEvent == nil {
@@ -312,7 +312,7 @@ func (g *EventHandler) handleLabelEventDeleted(ctx context.Context, deliveryID s
 func (g *EventHandler) OnLabelEventAny(callbacks ...LabelEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onLabelEvent == nil {
@@ -337,7 +337,7 @@ func (g *EventHandler) OnLabelEventAny(callbacks ...LabelEventHandleFunc) {
 func (g *EventHandler) SetOnLabelEventAny(callbacks ...LabelEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onLabelEvent == nil {

--- a/githubevents/events_marketplace_purchase.go
+++ b/githubevents/events_marketplace_purchase.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -107,33 +106,10 @@ func (g *EventHandler) handleMarketplacePurchaseEventPurchased(ctx context.Conte
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		MarketplacePurchaseEventPurchasedAction,
-		MarketplacePurchaseEventAnyAction,
-	} {
-		if _, ok := g.onMarketplacePurchaseEvent[action]; ok {
-			for _, h := range g.onMarketplacePurchaseEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.MarketplacePurchaseEvent](ctx, deliveryID, eventName, event,
+		g.onMarketplacePurchaseEvent[MarketplacePurchaseEventPurchasedAction],
+		g.onMarketplacePurchaseEvent[MarketplacePurchaseEventAnyAction],
+	)
 }
 
 // OnMarketplacePurchaseEventPendingChange registers callbacks listening to events of type github.MarketplacePurchaseEvent and action 'pending_change'.
@@ -193,33 +169,10 @@ func (g *EventHandler) handleMarketplacePurchaseEventPendingChange(ctx context.C
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		MarketplacePurchaseEventPendingChangeAction,
-		MarketplacePurchaseEventAnyAction,
-	} {
-		if _, ok := g.onMarketplacePurchaseEvent[action]; ok {
-			for _, h := range g.onMarketplacePurchaseEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.MarketplacePurchaseEvent](ctx, deliveryID, eventName, event,
+		g.onMarketplacePurchaseEvent[MarketplacePurchaseEventPendingChangeAction],
+		g.onMarketplacePurchaseEvent[MarketplacePurchaseEventAnyAction],
+	)
 }
 
 // OnMarketplacePurchaseEventPendingChangeCanceled registers callbacks listening to events of type github.MarketplacePurchaseEvent and action 'pending_change_canceled'.
@@ -279,33 +232,10 @@ func (g *EventHandler) handleMarketplacePurchaseEventPendingChangeCanceled(ctx c
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		MarketplacePurchaseEventPendingChangeCanceledAction,
-		MarketplacePurchaseEventAnyAction,
-	} {
-		if _, ok := g.onMarketplacePurchaseEvent[action]; ok {
-			for _, h := range g.onMarketplacePurchaseEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.MarketplacePurchaseEvent](ctx, deliveryID, eventName, event,
+		g.onMarketplacePurchaseEvent[MarketplacePurchaseEventPendingChangeCanceledAction],
+		g.onMarketplacePurchaseEvent[MarketplacePurchaseEventAnyAction],
+	)
 }
 
 // OnMarketplacePurchaseEventChanged registers callbacks listening to events of type github.MarketplacePurchaseEvent and action 'changed'.
@@ -365,33 +295,10 @@ func (g *EventHandler) handleMarketplacePurchaseEventChanged(ctx context.Context
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		MarketplacePurchaseEventChangedAction,
-		MarketplacePurchaseEventAnyAction,
-	} {
-		if _, ok := g.onMarketplacePurchaseEvent[action]; ok {
-			for _, h := range g.onMarketplacePurchaseEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.MarketplacePurchaseEvent](ctx, deliveryID, eventName, event,
+		g.onMarketplacePurchaseEvent[MarketplacePurchaseEventChangedAction],
+		g.onMarketplacePurchaseEvent[MarketplacePurchaseEventAnyAction],
+	)
 }
 
 // OnMarketplacePurchaseEventCanceled registers callbacks listening to events of type github.MarketplacePurchaseEvent and action 'canceled'.
@@ -451,33 +358,10 @@ func (g *EventHandler) handleMarketplacePurchaseEventCanceled(ctx context.Contex
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		MarketplacePurchaseEventCanceledAction,
-		MarketplacePurchaseEventAnyAction,
-	} {
-		if _, ok := g.onMarketplacePurchaseEvent[action]; ok {
-			for _, h := range g.onMarketplacePurchaseEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.MarketplacePurchaseEvent](ctx, deliveryID, eventName, event,
+		g.onMarketplacePurchaseEvent[MarketplacePurchaseEventCanceledAction],
+		g.onMarketplacePurchaseEvent[MarketplacePurchaseEventAnyAction],
+	)
 }
 
 // OnMarketplacePurchaseEventAny registers callbacks listening to any events of type github.MarketplacePurchaseEvent
@@ -530,29 +414,7 @@ func (g *EventHandler) handleMarketplacePurchaseEventAny(ctx context.Context, de
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onMarketplacePurchaseEvent[MarketplacePurchaseEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onMarketplacePurchaseEvent[MarketplacePurchaseEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.MarketplacePurchaseEvent](ctx, deliveryID, eventName, event, g.onMarketplacePurchaseEvent[MarketplacePurchaseEventAnyAction])
 }
 
 // MarketplacePurchaseEvent handles github.MarketplacePurchaseEvent.

--- a/githubevents/events_marketplace_purchase.go
+++ b/githubevents/events_marketplace_purchase.go
@@ -62,7 +62,7 @@ type MarketplacePurchaseEventHandleFunc func(ctx context.Context, deliveryID str
 func (g *EventHandler) OnMarketplacePurchaseEventPurchased(callbacks ...MarketplacePurchaseEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMarketplacePurchaseEvent == nil {
@@ -87,7 +87,7 @@ func (g *EventHandler) OnMarketplacePurchaseEventPurchased(callbacks ...Marketpl
 func (g *EventHandler) SetOnMarketplacePurchaseEventPurchased(callbacks ...MarketplacePurchaseEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMarketplacePurchaseEvent == nil {
@@ -148,7 +148,7 @@ func (g *EventHandler) handleMarketplacePurchaseEventPurchased(ctx context.Conte
 func (g *EventHandler) OnMarketplacePurchaseEventPendingChange(callbacks ...MarketplacePurchaseEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMarketplacePurchaseEvent == nil {
@@ -173,7 +173,7 @@ func (g *EventHandler) OnMarketplacePurchaseEventPendingChange(callbacks ...Mark
 func (g *EventHandler) SetOnMarketplacePurchaseEventPendingChange(callbacks ...MarketplacePurchaseEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMarketplacePurchaseEvent == nil {
@@ -234,7 +234,7 @@ func (g *EventHandler) handleMarketplacePurchaseEventPendingChange(ctx context.C
 func (g *EventHandler) OnMarketplacePurchaseEventPendingChangeCanceled(callbacks ...MarketplacePurchaseEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMarketplacePurchaseEvent == nil {
@@ -259,7 +259,7 @@ func (g *EventHandler) OnMarketplacePurchaseEventPendingChangeCanceled(callbacks
 func (g *EventHandler) SetOnMarketplacePurchaseEventPendingChangeCanceled(callbacks ...MarketplacePurchaseEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMarketplacePurchaseEvent == nil {
@@ -320,7 +320,7 @@ func (g *EventHandler) handleMarketplacePurchaseEventPendingChangeCanceled(ctx c
 func (g *EventHandler) OnMarketplacePurchaseEventChanged(callbacks ...MarketplacePurchaseEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMarketplacePurchaseEvent == nil {
@@ -345,7 +345,7 @@ func (g *EventHandler) OnMarketplacePurchaseEventChanged(callbacks ...Marketplac
 func (g *EventHandler) SetOnMarketplacePurchaseEventChanged(callbacks ...MarketplacePurchaseEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMarketplacePurchaseEvent == nil {
@@ -406,7 +406,7 @@ func (g *EventHandler) handleMarketplacePurchaseEventChanged(ctx context.Context
 func (g *EventHandler) OnMarketplacePurchaseEventCanceled(callbacks ...MarketplacePurchaseEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMarketplacePurchaseEvent == nil {
@@ -431,7 +431,7 @@ func (g *EventHandler) OnMarketplacePurchaseEventCanceled(callbacks ...Marketpla
 func (g *EventHandler) SetOnMarketplacePurchaseEventCanceled(callbacks ...MarketplacePurchaseEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMarketplacePurchaseEvent == nil {
@@ -492,7 +492,7 @@ func (g *EventHandler) handleMarketplacePurchaseEventCanceled(ctx context.Contex
 func (g *EventHandler) OnMarketplacePurchaseEventAny(callbacks ...MarketplacePurchaseEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMarketplacePurchaseEvent == nil {
@@ -517,7 +517,7 @@ func (g *EventHandler) OnMarketplacePurchaseEventAny(callbacks ...MarketplacePur
 func (g *EventHandler) SetOnMarketplacePurchaseEventAny(callbacks ...MarketplacePurchaseEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMarketplacePurchaseEvent == nil {

--- a/githubevents/events_member.go
+++ b/githubevents/events_member.go
@@ -54,7 +54,7 @@ type MemberEventHandleFunc func(ctx context.Context, deliveryID string, eventNam
 func (g *EventHandler) OnMemberEventAdded(callbacks ...MemberEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMemberEvent == nil {
@@ -79,7 +79,7 @@ func (g *EventHandler) OnMemberEventAdded(callbacks ...MemberEventHandleFunc) {
 func (g *EventHandler) SetOnMemberEventAdded(callbacks ...MemberEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMemberEvent == nil {
@@ -140,7 +140,7 @@ func (g *EventHandler) handleMemberEventAdded(ctx context.Context, deliveryID st
 func (g *EventHandler) OnMemberEventRemoved(callbacks ...MemberEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMemberEvent == nil {
@@ -165,7 +165,7 @@ func (g *EventHandler) OnMemberEventRemoved(callbacks ...MemberEventHandleFunc) 
 func (g *EventHandler) SetOnMemberEventRemoved(callbacks ...MemberEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMemberEvent == nil {
@@ -226,7 +226,7 @@ func (g *EventHandler) handleMemberEventRemoved(ctx context.Context, deliveryID 
 func (g *EventHandler) OnMemberEventEdited(callbacks ...MemberEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMemberEvent == nil {
@@ -251,7 +251,7 @@ func (g *EventHandler) OnMemberEventEdited(callbacks ...MemberEventHandleFunc) {
 func (g *EventHandler) SetOnMemberEventEdited(callbacks ...MemberEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMemberEvent == nil {
@@ -312,7 +312,7 @@ func (g *EventHandler) handleMemberEventEdited(ctx context.Context, deliveryID s
 func (g *EventHandler) OnMemberEventAny(callbacks ...MemberEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMemberEvent == nil {
@@ -337,7 +337,7 @@ func (g *EventHandler) OnMemberEventAny(callbacks ...MemberEventHandleFunc) {
 func (g *EventHandler) SetOnMemberEventAny(callbacks ...MemberEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMemberEvent == nil {

--- a/githubevents/events_member.go
+++ b/githubevents/events_member.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -99,33 +98,10 @@ func (g *EventHandler) handleMemberEventAdded(ctx context.Context, deliveryID st
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		MemberEventAddedAction,
-		MemberEventAnyAction,
-	} {
-		if _, ok := g.onMemberEvent[action]; ok {
-			for _, h := range g.onMemberEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.MemberEvent](ctx, deliveryID, eventName, event,
+		g.onMemberEvent[MemberEventAddedAction],
+		g.onMemberEvent[MemberEventAnyAction],
+	)
 }
 
 // OnMemberEventRemoved registers callbacks listening to events of type github.MemberEvent and action 'removed'.
@@ -185,33 +161,10 @@ func (g *EventHandler) handleMemberEventRemoved(ctx context.Context, deliveryID 
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		MemberEventRemovedAction,
-		MemberEventAnyAction,
-	} {
-		if _, ok := g.onMemberEvent[action]; ok {
-			for _, h := range g.onMemberEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.MemberEvent](ctx, deliveryID, eventName, event,
+		g.onMemberEvent[MemberEventRemovedAction],
+		g.onMemberEvent[MemberEventAnyAction],
+	)
 }
 
 // OnMemberEventEdited registers callbacks listening to events of type github.MemberEvent and action 'edited'.
@@ -271,33 +224,10 @@ func (g *EventHandler) handleMemberEventEdited(ctx context.Context, deliveryID s
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		MemberEventEditedAction,
-		MemberEventAnyAction,
-	} {
-		if _, ok := g.onMemberEvent[action]; ok {
-			for _, h := range g.onMemberEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.MemberEvent](ctx, deliveryID, eventName, event,
+		g.onMemberEvent[MemberEventEditedAction],
+		g.onMemberEvent[MemberEventAnyAction],
+	)
 }
 
 // OnMemberEventAny registers callbacks listening to any events of type github.MemberEvent
@@ -350,29 +280,7 @@ func (g *EventHandler) handleMemberEventAny(ctx context.Context, deliveryID stri
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onMemberEvent[MemberEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onMemberEvent[MemberEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.MemberEvent](ctx, deliveryID, eventName, event, g.onMemberEvent[MemberEventAnyAction])
 }
 
 // MemberEvent handles github.MemberEvent.

--- a/githubevents/events_membership.go
+++ b/githubevents/events_membership.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -95,33 +94,10 @@ func (g *EventHandler) handleMembershipEventAdded(ctx context.Context, deliveryI
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		MembershipEventAddedAction,
-		MembershipEventAnyAction,
-	} {
-		if _, ok := g.onMembershipEvent[action]; ok {
-			for _, h := range g.onMembershipEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.MembershipEvent](ctx, deliveryID, eventName, event,
+		g.onMembershipEvent[MembershipEventAddedAction],
+		g.onMembershipEvent[MembershipEventAnyAction],
+	)
 }
 
 // OnMembershipEventRemoved registers callbacks listening to events of type github.MembershipEvent and action 'removed'.
@@ -181,33 +157,10 @@ func (g *EventHandler) handleMembershipEventRemoved(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		MembershipEventRemovedAction,
-		MembershipEventAnyAction,
-	} {
-		if _, ok := g.onMembershipEvent[action]; ok {
-			for _, h := range g.onMembershipEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.MembershipEvent](ctx, deliveryID, eventName, event,
+		g.onMembershipEvent[MembershipEventRemovedAction],
+		g.onMembershipEvent[MembershipEventAnyAction],
+	)
 }
 
 // OnMembershipEventAny registers callbacks listening to any events of type github.MembershipEvent
@@ -260,29 +213,7 @@ func (g *EventHandler) handleMembershipEventAny(ctx context.Context, deliveryID 
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onMembershipEvent[MembershipEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onMembershipEvent[MembershipEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.MembershipEvent](ctx, deliveryID, eventName, event, g.onMembershipEvent[MembershipEventAnyAction])
 }
 
 // MembershipEvent handles github.MembershipEvent.

--- a/githubevents/events_membership.go
+++ b/githubevents/events_membership.go
@@ -50,7 +50,7 @@ type MembershipEventHandleFunc func(ctx context.Context, deliveryID string, even
 func (g *EventHandler) OnMembershipEventAdded(callbacks ...MembershipEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMembershipEvent == nil {
@@ -75,7 +75,7 @@ func (g *EventHandler) OnMembershipEventAdded(callbacks ...MembershipEventHandle
 func (g *EventHandler) SetOnMembershipEventAdded(callbacks ...MembershipEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMembershipEvent == nil {
@@ -136,7 +136,7 @@ func (g *EventHandler) handleMembershipEventAdded(ctx context.Context, deliveryI
 func (g *EventHandler) OnMembershipEventRemoved(callbacks ...MembershipEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMembershipEvent == nil {
@@ -161,7 +161,7 @@ func (g *EventHandler) OnMembershipEventRemoved(callbacks ...MembershipEventHand
 func (g *EventHandler) SetOnMembershipEventRemoved(callbacks ...MembershipEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMembershipEvent == nil {
@@ -222,7 +222,7 @@ func (g *EventHandler) handleMembershipEventRemoved(ctx context.Context, deliver
 func (g *EventHandler) OnMembershipEventAny(callbacks ...MembershipEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMembershipEvent == nil {
@@ -247,7 +247,7 @@ func (g *EventHandler) OnMembershipEventAny(callbacks ...MembershipEventHandleFu
 func (g *EventHandler) SetOnMembershipEventAny(callbacks ...MembershipEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMembershipEvent == nil {

--- a/githubevents/events_merge_group_event.go
+++ b/githubevents/events_merge_group_event.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -95,33 +94,10 @@ func (g *EventHandler) handleMergeGroupEventChecksRequested(ctx context.Context,
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		MergeGroupEventChecksRequestedAction,
-		MergeGroupEventAnyAction,
-	} {
-		if _, ok := g.onMergeGroupEvent[action]; ok {
-			for _, h := range g.onMergeGroupEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.MergeGroupEvent](ctx, deliveryID, eventName, event,
+		g.onMergeGroupEvent[MergeGroupEventChecksRequestedAction],
+		g.onMergeGroupEvent[MergeGroupEventAnyAction],
+	)
 }
 
 // OnMergeGroupEventDestroyed registers callbacks listening to events of type github.MergeGroupEvent and action 'destroyed'.
@@ -181,33 +157,10 @@ func (g *EventHandler) handleMergeGroupEventDestroyed(ctx context.Context, deliv
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		MergeGroupEventDestroyedAction,
-		MergeGroupEventAnyAction,
-	} {
-		if _, ok := g.onMergeGroupEvent[action]; ok {
-			for _, h := range g.onMergeGroupEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.MergeGroupEvent](ctx, deliveryID, eventName, event,
+		g.onMergeGroupEvent[MergeGroupEventDestroyedAction],
+		g.onMergeGroupEvent[MergeGroupEventAnyAction],
+	)
 }
 
 // OnMergeGroupEventAny registers callbacks listening to any events of type github.MergeGroupEvent
@@ -260,29 +213,7 @@ func (g *EventHandler) handleMergeGroupEventAny(ctx context.Context, deliveryID 
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onMergeGroupEvent[MergeGroupEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onMergeGroupEvent[MergeGroupEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.MergeGroupEvent](ctx, deliveryID, eventName, event, g.onMergeGroupEvent[MergeGroupEventAnyAction])
 }
 
 // MergeGroupEvent handles github.MergeGroupEvent.

--- a/githubevents/events_merge_group_event.go
+++ b/githubevents/events_merge_group_event.go
@@ -50,7 +50,7 @@ type MergeGroupEventHandleFunc func(ctx context.Context, deliveryID string, even
 func (g *EventHandler) OnMergeGroupEventChecksRequested(callbacks ...MergeGroupEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMergeGroupEvent == nil {
@@ -75,7 +75,7 @@ func (g *EventHandler) OnMergeGroupEventChecksRequested(callbacks ...MergeGroupE
 func (g *EventHandler) SetOnMergeGroupEventChecksRequested(callbacks ...MergeGroupEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMergeGroupEvent == nil {
@@ -136,7 +136,7 @@ func (g *EventHandler) handleMergeGroupEventChecksRequested(ctx context.Context,
 func (g *EventHandler) OnMergeGroupEventDestroyed(callbacks ...MergeGroupEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMergeGroupEvent == nil {
@@ -161,7 +161,7 @@ func (g *EventHandler) OnMergeGroupEventDestroyed(callbacks ...MergeGroupEventHa
 func (g *EventHandler) SetOnMergeGroupEventDestroyed(callbacks ...MergeGroupEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMergeGroupEvent == nil {
@@ -222,7 +222,7 @@ func (g *EventHandler) handleMergeGroupEventDestroyed(ctx context.Context, deliv
 func (g *EventHandler) OnMergeGroupEventAny(callbacks ...MergeGroupEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMergeGroupEvent == nil {
@@ -247,7 +247,7 @@ func (g *EventHandler) OnMergeGroupEventAny(callbacks ...MergeGroupEventHandleFu
 func (g *EventHandler) SetOnMergeGroupEventAny(callbacks ...MergeGroupEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMergeGroupEvent == nil {

--- a/githubevents/events_meta.go
+++ b/githubevents/events_meta.go
@@ -42,7 +42,7 @@ type MetaEventHandleFunc func(ctx context.Context, deliveryID string, eventName 
 func (g *EventHandler) OnMetaEventAny(callbacks ...MetaEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMetaEvent == nil {
@@ -67,7 +67,7 @@ func (g *EventHandler) OnMetaEventAny(callbacks ...MetaEventHandleFunc) {
 func (g *EventHandler) SetOnMetaEventAny(callbacks ...MetaEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMetaEvent == nil {

--- a/githubevents/events_meta.go
+++ b/githubevents/events_meta.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -80,29 +79,7 @@ func (g *EventHandler) handleMetaEventAny(ctx context.Context, deliveryID string
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onMetaEvent[MetaEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onMetaEvent[MetaEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.MetaEvent](ctx, deliveryID, eventName, event, g.onMetaEvent[MetaEventAnyAction])
 }
 
 // MetaEvent handles github.MetaEvent.

--- a/githubevents/events_milestone.go
+++ b/githubevents/events_milestone.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -107,33 +106,10 @@ func (g *EventHandler) handleMilestoneEventCreated(ctx context.Context, delivery
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		MilestoneEventCreatedAction,
-		MilestoneEventAnyAction,
-	} {
-		if _, ok := g.onMilestoneEvent[action]; ok {
-			for _, h := range g.onMilestoneEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.MilestoneEvent](ctx, deliveryID, eventName, event,
+		g.onMilestoneEvent[MilestoneEventCreatedAction],
+		g.onMilestoneEvent[MilestoneEventAnyAction],
+	)
 }
 
 // OnMilestoneEventClosed registers callbacks listening to events of type github.MilestoneEvent and action 'closed'.
@@ -193,33 +169,10 @@ func (g *EventHandler) handleMilestoneEventClosed(ctx context.Context, deliveryI
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		MilestoneEventClosedAction,
-		MilestoneEventAnyAction,
-	} {
-		if _, ok := g.onMilestoneEvent[action]; ok {
-			for _, h := range g.onMilestoneEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.MilestoneEvent](ctx, deliveryID, eventName, event,
+		g.onMilestoneEvent[MilestoneEventClosedAction],
+		g.onMilestoneEvent[MilestoneEventAnyAction],
+	)
 }
 
 // OnMilestoneEventOpened registers callbacks listening to events of type github.MilestoneEvent and action 'opened'.
@@ -279,33 +232,10 @@ func (g *EventHandler) handleMilestoneEventOpened(ctx context.Context, deliveryI
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		MilestoneEventOpenedAction,
-		MilestoneEventAnyAction,
-	} {
-		if _, ok := g.onMilestoneEvent[action]; ok {
-			for _, h := range g.onMilestoneEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.MilestoneEvent](ctx, deliveryID, eventName, event,
+		g.onMilestoneEvent[MilestoneEventOpenedAction],
+		g.onMilestoneEvent[MilestoneEventAnyAction],
+	)
 }
 
 // OnMilestoneEventEdited registers callbacks listening to events of type github.MilestoneEvent and action 'edited'.
@@ -365,33 +295,10 @@ func (g *EventHandler) handleMilestoneEventEdited(ctx context.Context, deliveryI
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		MilestoneEventEditedAction,
-		MilestoneEventAnyAction,
-	} {
-		if _, ok := g.onMilestoneEvent[action]; ok {
-			for _, h := range g.onMilestoneEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.MilestoneEvent](ctx, deliveryID, eventName, event,
+		g.onMilestoneEvent[MilestoneEventEditedAction],
+		g.onMilestoneEvent[MilestoneEventAnyAction],
+	)
 }
 
 // OnMilestoneEventDeleted registers callbacks listening to events of type github.MilestoneEvent and action 'deleted'.
@@ -451,33 +358,10 @@ func (g *EventHandler) handleMilestoneEventDeleted(ctx context.Context, delivery
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		MilestoneEventDeletedAction,
-		MilestoneEventAnyAction,
-	} {
-		if _, ok := g.onMilestoneEvent[action]; ok {
-			for _, h := range g.onMilestoneEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.MilestoneEvent](ctx, deliveryID, eventName, event,
+		g.onMilestoneEvent[MilestoneEventDeletedAction],
+		g.onMilestoneEvent[MilestoneEventAnyAction],
+	)
 }
 
 // OnMilestoneEventAny registers callbacks listening to any events of type github.MilestoneEvent
@@ -530,29 +414,7 @@ func (g *EventHandler) handleMilestoneEventAny(ctx context.Context, deliveryID s
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onMilestoneEvent[MilestoneEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onMilestoneEvent[MilestoneEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.MilestoneEvent](ctx, deliveryID, eventName, event, g.onMilestoneEvent[MilestoneEventAnyAction])
 }
 
 // MilestoneEvent handles github.MilestoneEvent.

--- a/githubevents/events_milestone.go
+++ b/githubevents/events_milestone.go
@@ -62,7 +62,7 @@ type MilestoneEventHandleFunc func(ctx context.Context, deliveryID string, event
 func (g *EventHandler) OnMilestoneEventCreated(callbacks ...MilestoneEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMilestoneEvent == nil {
@@ -87,7 +87,7 @@ func (g *EventHandler) OnMilestoneEventCreated(callbacks ...MilestoneEventHandle
 func (g *EventHandler) SetOnMilestoneEventCreated(callbacks ...MilestoneEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMilestoneEvent == nil {
@@ -148,7 +148,7 @@ func (g *EventHandler) handleMilestoneEventCreated(ctx context.Context, delivery
 func (g *EventHandler) OnMilestoneEventClosed(callbacks ...MilestoneEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMilestoneEvent == nil {
@@ -173,7 +173,7 @@ func (g *EventHandler) OnMilestoneEventClosed(callbacks ...MilestoneEventHandleF
 func (g *EventHandler) SetOnMilestoneEventClosed(callbacks ...MilestoneEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMilestoneEvent == nil {
@@ -234,7 +234,7 @@ func (g *EventHandler) handleMilestoneEventClosed(ctx context.Context, deliveryI
 func (g *EventHandler) OnMilestoneEventOpened(callbacks ...MilestoneEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMilestoneEvent == nil {
@@ -259,7 +259,7 @@ func (g *EventHandler) OnMilestoneEventOpened(callbacks ...MilestoneEventHandleF
 func (g *EventHandler) SetOnMilestoneEventOpened(callbacks ...MilestoneEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMilestoneEvent == nil {
@@ -320,7 +320,7 @@ func (g *EventHandler) handleMilestoneEventOpened(ctx context.Context, deliveryI
 func (g *EventHandler) OnMilestoneEventEdited(callbacks ...MilestoneEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMilestoneEvent == nil {
@@ -345,7 +345,7 @@ func (g *EventHandler) OnMilestoneEventEdited(callbacks ...MilestoneEventHandleF
 func (g *EventHandler) SetOnMilestoneEventEdited(callbacks ...MilestoneEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMilestoneEvent == nil {
@@ -406,7 +406,7 @@ func (g *EventHandler) handleMilestoneEventEdited(ctx context.Context, deliveryI
 func (g *EventHandler) OnMilestoneEventDeleted(callbacks ...MilestoneEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMilestoneEvent == nil {
@@ -431,7 +431,7 @@ func (g *EventHandler) OnMilestoneEventDeleted(callbacks ...MilestoneEventHandle
 func (g *EventHandler) SetOnMilestoneEventDeleted(callbacks ...MilestoneEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMilestoneEvent == nil {
@@ -492,7 +492,7 @@ func (g *EventHandler) handleMilestoneEventDeleted(ctx context.Context, delivery
 func (g *EventHandler) OnMilestoneEventAny(callbacks ...MilestoneEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMilestoneEvent == nil {
@@ -517,7 +517,7 @@ func (g *EventHandler) OnMilestoneEventAny(callbacks ...MilestoneEventHandleFunc
 func (g *EventHandler) SetOnMilestoneEventAny(callbacks ...MilestoneEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onMilestoneEvent == nil {

--- a/githubevents/events_org_block.go
+++ b/githubevents/events_org_block.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -95,33 +94,10 @@ func (g *EventHandler) handleOrgBlockEventBlocked(ctx context.Context, deliveryI
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		OrgBlockEventBlockedAction,
-		OrgBlockEventAnyAction,
-	} {
-		if _, ok := g.onOrgBlockEvent[action]; ok {
-			for _, h := range g.onOrgBlockEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.OrgBlockEvent](ctx, deliveryID, eventName, event,
+		g.onOrgBlockEvent[OrgBlockEventBlockedAction],
+		g.onOrgBlockEvent[OrgBlockEventAnyAction],
+	)
 }
 
 // OnOrgBlockEventUnblocked registers callbacks listening to events of type github.OrgBlockEvent and action 'unblocked'.
@@ -181,33 +157,10 @@ func (g *EventHandler) handleOrgBlockEventUnblocked(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		OrgBlockEventUnblockedAction,
-		OrgBlockEventAnyAction,
-	} {
-		if _, ok := g.onOrgBlockEvent[action]; ok {
-			for _, h := range g.onOrgBlockEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.OrgBlockEvent](ctx, deliveryID, eventName, event,
+		g.onOrgBlockEvent[OrgBlockEventUnblockedAction],
+		g.onOrgBlockEvent[OrgBlockEventAnyAction],
+	)
 }
 
 // OnOrgBlockEventAny registers callbacks listening to any events of type github.OrgBlockEvent
@@ -260,29 +213,7 @@ func (g *EventHandler) handleOrgBlockEventAny(ctx context.Context, deliveryID st
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onOrgBlockEvent[OrgBlockEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onOrgBlockEvent[OrgBlockEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.OrgBlockEvent](ctx, deliveryID, eventName, event, g.onOrgBlockEvent[OrgBlockEventAnyAction])
 }
 
 // OrgBlockEvent handles github.OrgBlockEvent.

--- a/githubevents/events_org_block.go
+++ b/githubevents/events_org_block.go
@@ -50,7 +50,7 @@ type OrgBlockEventHandleFunc func(ctx context.Context, deliveryID string, eventN
 func (g *EventHandler) OnOrgBlockEventBlocked(callbacks ...OrgBlockEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onOrgBlockEvent == nil {
@@ -75,7 +75,7 @@ func (g *EventHandler) OnOrgBlockEventBlocked(callbacks ...OrgBlockEventHandleFu
 func (g *EventHandler) SetOnOrgBlockEventBlocked(callbacks ...OrgBlockEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onOrgBlockEvent == nil {
@@ -136,7 +136,7 @@ func (g *EventHandler) handleOrgBlockEventBlocked(ctx context.Context, deliveryI
 func (g *EventHandler) OnOrgBlockEventUnblocked(callbacks ...OrgBlockEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onOrgBlockEvent == nil {
@@ -161,7 +161,7 @@ func (g *EventHandler) OnOrgBlockEventUnblocked(callbacks ...OrgBlockEventHandle
 func (g *EventHandler) SetOnOrgBlockEventUnblocked(callbacks ...OrgBlockEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onOrgBlockEvent == nil {
@@ -222,7 +222,7 @@ func (g *EventHandler) handleOrgBlockEventUnblocked(ctx context.Context, deliver
 func (g *EventHandler) OnOrgBlockEventAny(callbacks ...OrgBlockEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onOrgBlockEvent == nil {
@@ -247,7 +247,7 @@ func (g *EventHandler) OnOrgBlockEventAny(callbacks ...OrgBlockEventHandleFunc) 
 func (g *EventHandler) SetOnOrgBlockEventAny(callbacks ...OrgBlockEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onOrgBlockEvent == nil {

--- a/githubevents/events_organization.go
+++ b/githubevents/events_organization.go
@@ -62,7 +62,7 @@ type OrganizationEventHandleFunc func(ctx context.Context, deliveryID string, ev
 func (g *EventHandler) OnOrganizationEventDeleted(callbacks ...OrganizationEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onOrganizationEvent == nil {
@@ -87,7 +87,7 @@ func (g *EventHandler) OnOrganizationEventDeleted(callbacks ...OrganizationEvent
 func (g *EventHandler) SetOnOrganizationEventDeleted(callbacks ...OrganizationEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onOrganizationEvent == nil {
@@ -148,7 +148,7 @@ func (g *EventHandler) handleOrganizationEventDeleted(ctx context.Context, deliv
 func (g *EventHandler) OnOrganizationEventRenamed(callbacks ...OrganizationEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onOrganizationEvent == nil {
@@ -173,7 +173,7 @@ func (g *EventHandler) OnOrganizationEventRenamed(callbacks ...OrganizationEvent
 func (g *EventHandler) SetOnOrganizationEventRenamed(callbacks ...OrganizationEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onOrganizationEvent == nil {
@@ -234,7 +234,7 @@ func (g *EventHandler) handleOrganizationEventRenamed(ctx context.Context, deliv
 func (g *EventHandler) OnOrganizationEventMemberAdded(callbacks ...OrganizationEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onOrganizationEvent == nil {
@@ -259,7 +259,7 @@ func (g *EventHandler) OnOrganizationEventMemberAdded(callbacks ...OrganizationE
 func (g *EventHandler) SetOnOrganizationEventMemberAdded(callbacks ...OrganizationEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onOrganizationEvent == nil {
@@ -320,7 +320,7 @@ func (g *EventHandler) handleOrganizationEventMemberAdded(ctx context.Context, d
 func (g *EventHandler) OnOrganizationEventMemberRemoved(callbacks ...OrganizationEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onOrganizationEvent == nil {
@@ -345,7 +345,7 @@ func (g *EventHandler) OnOrganizationEventMemberRemoved(callbacks ...Organizatio
 func (g *EventHandler) SetOnOrganizationEventMemberRemoved(callbacks ...OrganizationEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onOrganizationEvent == nil {
@@ -406,7 +406,7 @@ func (g *EventHandler) handleOrganizationEventMemberRemoved(ctx context.Context,
 func (g *EventHandler) OnOrganizationEventMemberInvited(callbacks ...OrganizationEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onOrganizationEvent == nil {
@@ -431,7 +431,7 @@ func (g *EventHandler) OnOrganizationEventMemberInvited(callbacks ...Organizatio
 func (g *EventHandler) SetOnOrganizationEventMemberInvited(callbacks ...OrganizationEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onOrganizationEvent == nil {
@@ -492,7 +492,7 @@ func (g *EventHandler) handleOrganizationEventMemberInvited(ctx context.Context,
 func (g *EventHandler) OnOrganizationEventAny(callbacks ...OrganizationEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onOrganizationEvent == nil {
@@ -517,7 +517,7 @@ func (g *EventHandler) OnOrganizationEventAny(callbacks ...OrganizationEventHand
 func (g *EventHandler) SetOnOrganizationEventAny(callbacks ...OrganizationEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onOrganizationEvent == nil {

--- a/githubevents/events_organization.go
+++ b/githubevents/events_organization.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -107,33 +106,10 @@ func (g *EventHandler) handleOrganizationEventDeleted(ctx context.Context, deliv
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		OrganizationEventDeletedAction,
-		OrganizationEventAnyAction,
-	} {
-		if _, ok := g.onOrganizationEvent[action]; ok {
-			for _, h := range g.onOrganizationEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.OrganizationEvent](ctx, deliveryID, eventName, event,
+		g.onOrganizationEvent[OrganizationEventDeletedAction],
+		g.onOrganizationEvent[OrganizationEventAnyAction],
+	)
 }
 
 // OnOrganizationEventRenamed registers callbacks listening to events of type github.OrganizationEvent and action 'renamed'.
@@ -193,33 +169,10 @@ func (g *EventHandler) handleOrganizationEventRenamed(ctx context.Context, deliv
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		OrganizationEventRenamedAction,
-		OrganizationEventAnyAction,
-	} {
-		if _, ok := g.onOrganizationEvent[action]; ok {
-			for _, h := range g.onOrganizationEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.OrganizationEvent](ctx, deliveryID, eventName, event,
+		g.onOrganizationEvent[OrganizationEventRenamedAction],
+		g.onOrganizationEvent[OrganizationEventAnyAction],
+	)
 }
 
 // OnOrganizationEventMemberAdded registers callbacks listening to events of type github.OrganizationEvent and action 'member_added'.
@@ -279,33 +232,10 @@ func (g *EventHandler) handleOrganizationEventMemberAdded(ctx context.Context, d
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		OrganizationEventMemberAddedAction,
-		OrganizationEventAnyAction,
-	} {
-		if _, ok := g.onOrganizationEvent[action]; ok {
-			for _, h := range g.onOrganizationEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.OrganizationEvent](ctx, deliveryID, eventName, event,
+		g.onOrganizationEvent[OrganizationEventMemberAddedAction],
+		g.onOrganizationEvent[OrganizationEventAnyAction],
+	)
 }
 
 // OnOrganizationEventMemberRemoved registers callbacks listening to events of type github.OrganizationEvent and action 'member_removed'.
@@ -365,33 +295,10 @@ func (g *EventHandler) handleOrganizationEventMemberRemoved(ctx context.Context,
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		OrganizationEventMemberRemovedAction,
-		OrganizationEventAnyAction,
-	} {
-		if _, ok := g.onOrganizationEvent[action]; ok {
-			for _, h := range g.onOrganizationEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.OrganizationEvent](ctx, deliveryID, eventName, event,
+		g.onOrganizationEvent[OrganizationEventMemberRemovedAction],
+		g.onOrganizationEvent[OrganizationEventAnyAction],
+	)
 }
 
 // OnOrganizationEventMemberInvited registers callbacks listening to events of type github.OrganizationEvent and action 'member_invited'.
@@ -451,33 +358,10 @@ func (g *EventHandler) handleOrganizationEventMemberInvited(ctx context.Context,
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		OrganizationEventMemberInvitedAction,
-		OrganizationEventAnyAction,
-	} {
-		if _, ok := g.onOrganizationEvent[action]; ok {
-			for _, h := range g.onOrganizationEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.OrganizationEvent](ctx, deliveryID, eventName, event,
+		g.onOrganizationEvent[OrganizationEventMemberInvitedAction],
+		g.onOrganizationEvent[OrganizationEventAnyAction],
+	)
 }
 
 // OnOrganizationEventAny registers callbacks listening to any events of type github.OrganizationEvent
@@ -530,29 +414,7 @@ func (g *EventHandler) handleOrganizationEventAny(ctx context.Context, deliveryI
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onOrganizationEvent[OrganizationEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onOrganizationEvent[OrganizationEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.OrganizationEvent](ctx, deliveryID, eventName, event, g.onOrganizationEvent[OrganizationEventAnyAction])
 }
 
 // OrganizationEvent handles github.OrganizationEvent.

--- a/githubevents/events_package.go
+++ b/githubevents/events_package.go
@@ -50,7 +50,7 @@ type PackageEventHandleFunc func(ctx context.Context, deliveryID string, eventNa
 func (g *EventHandler) OnPackageEventPublished(callbacks ...PackageEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPackageEvent == nil {
@@ -75,7 +75,7 @@ func (g *EventHandler) OnPackageEventPublished(callbacks ...PackageEventHandleFu
 func (g *EventHandler) SetOnPackageEventPublished(callbacks ...PackageEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPackageEvent == nil {
@@ -136,7 +136,7 @@ func (g *EventHandler) handlePackageEventPublished(ctx context.Context, delivery
 func (g *EventHandler) OnPackageEventUpdated(callbacks ...PackageEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPackageEvent == nil {
@@ -161,7 +161,7 @@ func (g *EventHandler) OnPackageEventUpdated(callbacks ...PackageEventHandleFunc
 func (g *EventHandler) SetOnPackageEventUpdated(callbacks ...PackageEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPackageEvent == nil {
@@ -222,7 +222,7 @@ func (g *EventHandler) handlePackageEventUpdated(ctx context.Context, deliveryID
 func (g *EventHandler) OnPackageEventAny(callbacks ...PackageEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPackageEvent == nil {
@@ -247,7 +247,7 @@ func (g *EventHandler) OnPackageEventAny(callbacks ...PackageEventHandleFunc) {
 func (g *EventHandler) SetOnPackageEventAny(callbacks ...PackageEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPackageEvent == nil {

--- a/githubevents/events_package.go
+++ b/githubevents/events_package.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -95,33 +94,10 @@ func (g *EventHandler) handlePackageEventPublished(ctx context.Context, delivery
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		PackageEventPublishedAction,
-		PackageEventAnyAction,
-	} {
-		if _, ok := g.onPackageEvent[action]; ok {
-			for _, h := range g.onPackageEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PackageEvent](ctx, deliveryID, eventName, event,
+		g.onPackageEvent[PackageEventPublishedAction],
+		g.onPackageEvent[PackageEventAnyAction],
+	)
 }
 
 // OnPackageEventUpdated registers callbacks listening to events of type github.PackageEvent and action 'updated'.
@@ -181,33 +157,10 @@ func (g *EventHandler) handlePackageEventUpdated(ctx context.Context, deliveryID
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		PackageEventUpdatedAction,
-		PackageEventAnyAction,
-	} {
-		if _, ok := g.onPackageEvent[action]; ok {
-			for _, h := range g.onPackageEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PackageEvent](ctx, deliveryID, eventName, event,
+		g.onPackageEvent[PackageEventUpdatedAction],
+		g.onPackageEvent[PackageEventAnyAction],
+	)
 }
 
 // OnPackageEventAny registers callbacks listening to any events of type github.PackageEvent
@@ -260,29 +213,7 @@ func (g *EventHandler) handlePackageEventAny(ctx context.Context, deliveryID str
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onPackageEvent[PackageEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onPackageEvent[PackageEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PackageEvent](ctx, deliveryID, eventName, event, g.onPackageEvent[PackageEventAnyAction])
 }
 
 // PackageEvent handles github.PackageEvent.

--- a/githubevents/events_page_build.go
+++ b/githubevents/events_page_build.go
@@ -42,7 +42,7 @@ type PageBuildEventHandleFunc func(ctx context.Context, deliveryID string, event
 func (g *EventHandler) OnPageBuildEventAny(callbacks ...PageBuildEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPageBuildEvent == nil {
@@ -67,7 +67,7 @@ func (g *EventHandler) OnPageBuildEventAny(callbacks ...PageBuildEventHandleFunc
 func (g *EventHandler) SetOnPageBuildEventAny(callbacks ...PageBuildEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPageBuildEvent == nil {

--- a/githubevents/events_page_build.go
+++ b/githubevents/events_page_build.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -80,29 +79,7 @@ func (g *EventHandler) handlePageBuildEventAny(ctx context.Context, deliveryID s
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onPageBuildEvent[PageBuildEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onPageBuildEvent[PageBuildEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PageBuildEvent](ctx, deliveryID, eventName, event, g.onPageBuildEvent[PageBuildEventAnyAction])
 }
 
 // PageBuildEvent handles github.PageBuildEvent.

--- a/githubevents/events_ping.go
+++ b/githubevents/events_ping.go
@@ -42,7 +42,7 @@ type PingEventHandleFunc func(ctx context.Context, deliveryID string, eventName 
 func (g *EventHandler) OnPingEventAny(callbacks ...PingEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPingEvent == nil {
@@ -67,7 +67,7 @@ func (g *EventHandler) OnPingEventAny(callbacks ...PingEventHandleFunc) {
 func (g *EventHandler) SetOnPingEventAny(callbacks ...PingEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPingEvent == nil {

--- a/githubevents/events_ping.go
+++ b/githubevents/events_ping.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -80,29 +79,7 @@ func (g *EventHandler) handlePingEventAny(ctx context.Context, deliveryID string
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onPingEvent[PingEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onPingEvent[PingEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PingEvent](ctx, deliveryID, eventName, event, g.onPingEvent[PingEventAnyAction])
 }
 
 // PingEvent handles github.PingEvent.

--- a/githubevents/events_project_v2.go
+++ b/githubevents/events_project_v2.go
@@ -62,7 +62,7 @@ type ProjectV2EventHandleFunc func(ctx context.Context, deliveryID string, event
 func (g *EventHandler) OnProjectEventCreated(callbacks ...ProjectV2EventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onProjectV2Event == nil {
@@ -87,7 +87,7 @@ func (g *EventHandler) OnProjectEventCreated(callbacks ...ProjectV2EventHandleFu
 func (g *EventHandler) SetOnProjectEventCreated(callbacks ...ProjectV2EventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onProjectV2Event == nil {
@@ -148,7 +148,7 @@ func (g *EventHandler) handleProjectEventCreated(ctx context.Context, deliveryID
 func (g *EventHandler) OnProjectEventEdited(callbacks ...ProjectV2EventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onProjectV2Event == nil {
@@ -173,7 +173,7 @@ func (g *EventHandler) OnProjectEventEdited(callbacks ...ProjectV2EventHandleFun
 func (g *EventHandler) SetOnProjectEventEdited(callbacks ...ProjectV2EventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onProjectV2Event == nil {
@@ -234,7 +234,7 @@ func (g *EventHandler) handleProjectEventEdited(ctx context.Context, deliveryID 
 func (g *EventHandler) OnProjectEventClosed(callbacks ...ProjectV2EventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onProjectV2Event == nil {
@@ -259,7 +259,7 @@ func (g *EventHandler) OnProjectEventClosed(callbacks ...ProjectV2EventHandleFun
 func (g *EventHandler) SetOnProjectEventClosed(callbacks ...ProjectV2EventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onProjectV2Event == nil {
@@ -320,7 +320,7 @@ func (g *EventHandler) handleProjectEventClosed(ctx context.Context, deliveryID 
 func (g *EventHandler) OnProjectEventReopened(callbacks ...ProjectV2EventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onProjectV2Event == nil {
@@ -345,7 +345,7 @@ func (g *EventHandler) OnProjectEventReopened(callbacks ...ProjectV2EventHandleF
 func (g *EventHandler) SetOnProjectEventReopened(callbacks ...ProjectV2EventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onProjectV2Event == nil {
@@ -406,7 +406,7 @@ func (g *EventHandler) handleProjectEventReopened(ctx context.Context, deliveryI
 func (g *EventHandler) OnProjectEventDeleted(callbacks ...ProjectV2EventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onProjectV2Event == nil {
@@ -431,7 +431,7 @@ func (g *EventHandler) OnProjectEventDeleted(callbacks ...ProjectV2EventHandleFu
 func (g *EventHandler) SetOnProjectEventDeleted(callbacks ...ProjectV2EventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onProjectV2Event == nil {
@@ -492,7 +492,7 @@ func (g *EventHandler) handleProjectEventDeleted(ctx context.Context, deliveryID
 func (g *EventHandler) OnProjectV2EventAny(callbacks ...ProjectV2EventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onProjectV2Event == nil {
@@ -517,7 +517,7 @@ func (g *EventHandler) OnProjectV2EventAny(callbacks ...ProjectV2EventHandleFunc
 func (g *EventHandler) SetOnProjectV2EventAny(callbacks ...ProjectV2EventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onProjectV2Event == nil {

--- a/githubevents/events_project_v2.go
+++ b/githubevents/events_project_v2.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -107,33 +106,10 @@ func (g *EventHandler) handleProjectEventCreated(ctx context.Context, deliveryID
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		ProjectEventCreatedAction,
-		ProjectV2EventAnyAction,
-	} {
-		if _, ok := g.onProjectV2Event[action]; ok {
-			for _, h := range g.onProjectV2Event[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.ProjectV2Event](ctx, deliveryID, eventName, event,
+		g.onProjectV2Event[ProjectEventCreatedAction],
+		g.onProjectV2Event[ProjectV2EventAnyAction],
+	)
 }
 
 // OnProjectEventEdited registers callbacks listening to events of type github.ProjectV2Event and action 'edited'.
@@ -193,33 +169,10 @@ func (g *EventHandler) handleProjectEventEdited(ctx context.Context, deliveryID 
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		ProjectEventEditedAction,
-		ProjectV2EventAnyAction,
-	} {
-		if _, ok := g.onProjectV2Event[action]; ok {
-			for _, h := range g.onProjectV2Event[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.ProjectV2Event](ctx, deliveryID, eventName, event,
+		g.onProjectV2Event[ProjectEventEditedAction],
+		g.onProjectV2Event[ProjectV2EventAnyAction],
+	)
 }
 
 // OnProjectEventClosed registers callbacks listening to events of type github.ProjectV2Event and action 'closed'.
@@ -279,33 +232,10 @@ func (g *EventHandler) handleProjectEventClosed(ctx context.Context, deliveryID 
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		ProjectEventClosedAction,
-		ProjectV2EventAnyAction,
-	} {
-		if _, ok := g.onProjectV2Event[action]; ok {
-			for _, h := range g.onProjectV2Event[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.ProjectV2Event](ctx, deliveryID, eventName, event,
+		g.onProjectV2Event[ProjectEventClosedAction],
+		g.onProjectV2Event[ProjectV2EventAnyAction],
+	)
 }
 
 // OnProjectEventReopened registers callbacks listening to events of type github.ProjectV2Event and action 'reopened'.
@@ -365,33 +295,10 @@ func (g *EventHandler) handleProjectEventReopened(ctx context.Context, deliveryI
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		ProjectEventReopenedAction,
-		ProjectV2EventAnyAction,
-	} {
-		if _, ok := g.onProjectV2Event[action]; ok {
-			for _, h := range g.onProjectV2Event[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.ProjectV2Event](ctx, deliveryID, eventName, event,
+		g.onProjectV2Event[ProjectEventReopenedAction],
+		g.onProjectV2Event[ProjectV2EventAnyAction],
+	)
 }
 
 // OnProjectEventDeleted registers callbacks listening to events of type github.ProjectV2Event and action 'deleted'.
@@ -451,33 +358,10 @@ func (g *EventHandler) handleProjectEventDeleted(ctx context.Context, deliveryID
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		ProjectEventDeletedAction,
-		ProjectV2EventAnyAction,
-	} {
-		if _, ok := g.onProjectV2Event[action]; ok {
-			for _, h := range g.onProjectV2Event[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.ProjectV2Event](ctx, deliveryID, eventName, event,
+		g.onProjectV2Event[ProjectEventDeletedAction],
+		g.onProjectV2Event[ProjectV2EventAnyAction],
+	)
 }
 
 // OnProjectV2EventAny registers callbacks listening to any events of type github.ProjectV2Event
@@ -530,29 +414,7 @@ func (g *EventHandler) handleProjectV2EventAny(ctx context.Context, deliveryID s
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onProjectV2Event[ProjectV2EventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onProjectV2Event[ProjectV2EventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.ProjectV2Event](ctx, deliveryID, eventName, event, g.onProjectV2Event[ProjectV2EventAnyAction])
 }
 
 // ProjectV2Event handles github.ProjectV2Event.

--- a/githubevents/events_project_v2_item.go
+++ b/githubevents/events_project_v2_item.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -115,33 +114,10 @@ func (g *EventHandler) handleProjectItemEventCreated(ctx context.Context, delive
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		ProjectItemEventCreatedAction,
-		ProjectV2ItemEventAnyAction,
-	} {
-		if _, ok := g.onProjectV2ItemEvent[action]; ok {
-			for _, h := range g.onProjectV2ItemEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.ProjectV2ItemEvent](ctx, deliveryID, eventName, event,
+		g.onProjectV2ItemEvent[ProjectItemEventCreatedAction],
+		g.onProjectV2ItemEvent[ProjectV2ItemEventAnyAction],
+	)
 }
 
 // OnProjectItemEventEdited registers callbacks listening to events of type github.ProjectV2ItemEvent and action 'edited'.
@@ -201,33 +177,10 @@ func (g *EventHandler) handleProjectItemEventEdited(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		ProjectItemEventEditedAction,
-		ProjectV2ItemEventAnyAction,
-	} {
-		if _, ok := g.onProjectV2ItemEvent[action]; ok {
-			for _, h := range g.onProjectV2ItemEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.ProjectV2ItemEvent](ctx, deliveryID, eventName, event,
+		g.onProjectV2ItemEvent[ProjectItemEventEditedAction],
+		g.onProjectV2ItemEvent[ProjectV2ItemEventAnyAction],
+	)
 }
 
 // OnProjectItemEventClosed registers callbacks listening to events of type github.ProjectV2ItemEvent and action 'closed'.
@@ -287,33 +240,10 @@ func (g *EventHandler) handleProjectItemEventClosed(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		ProjectItemEventClosedAction,
-		ProjectV2ItemEventAnyAction,
-	} {
-		if _, ok := g.onProjectV2ItemEvent[action]; ok {
-			for _, h := range g.onProjectV2ItemEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.ProjectV2ItemEvent](ctx, deliveryID, eventName, event,
+		g.onProjectV2ItemEvent[ProjectItemEventClosedAction],
+		g.onProjectV2ItemEvent[ProjectV2ItemEventAnyAction],
+	)
 }
 
 // OnProjectItemEventReopened registers callbacks listening to events of type github.ProjectV2ItemEvent and action 'reopened'.
@@ -373,33 +303,10 @@ func (g *EventHandler) handleProjectItemEventReopened(ctx context.Context, deliv
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		ProjectItemEventReopenedAction,
-		ProjectV2ItemEventAnyAction,
-	} {
-		if _, ok := g.onProjectV2ItemEvent[action]; ok {
-			for _, h := range g.onProjectV2ItemEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.ProjectV2ItemEvent](ctx, deliveryID, eventName, event,
+		g.onProjectV2ItemEvent[ProjectItemEventReopenedAction],
+		g.onProjectV2ItemEvent[ProjectV2ItemEventAnyAction],
+	)
 }
 
 // OnProjectItemEventDeleted registers callbacks listening to events of type github.ProjectV2ItemEvent and action 'deleted'.
@@ -459,33 +366,10 @@ func (g *EventHandler) handleProjectItemEventDeleted(ctx context.Context, delive
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		ProjectItemEventDeletedAction,
-		ProjectV2ItemEventAnyAction,
-	} {
-		if _, ok := g.onProjectV2ItemEvent[action]; ok {
-			for _, h := range g.onProjectV2ItemEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.ProjectV2ItemEvent](ctx, deliveryID, eventName, event,
+		g.onProjectV2ItemEvent[ProjectItemEventDeletedAction],
+		g.onProjectV2ItemEvent[ProjectV2ItemEventAnyAction],
+	)
 }
 
 // OnProjectItemEventConverted registers callbacks listening to events of type github.ProjectV2ItemEvent and action 'converted'.
@@ -545,33 +429,10 @@ func (g *EventHandler) handleProjectItemEventConverted(ctx context.Context, deli
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		ProjectItemEventConvertedAction,
-		ProjectV2ItemEventAnyAction,
-	} {
-		if _, ok := g.onProjectV2ItemEvent[action]; ok {
-			for _, h := range g.onProjectV2ItemEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.ProjectV2ItemEvent](ctx, deliveryID, eventName, event,
+		g.onProjectV2ItemEvent[ProjectItemEventConvertedAction],
+		g.onProjectV2ItemEvent[ProjectV2ItemEventAnyAction],
+	)
 }
 
 // OnProjectItemEventRestored registers callbacks listening to events of type github.ProjectV2ItemEvent and action 'restored'.
@@ -631,33 +492,10 @@ func (g *EventHandler) handleProjectItemEventRestored(ctx context.Context, deliv
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		ProjectItemEventRestoredAction,
-		ProjectV2ItemEventAnyAction,
-	} {
-		if _, ok := g.onProjectV2ItemEvent[action]; ok {
-			for _, h := range g.onProjectV2ItemEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.ProjectV2ItemEvent](ctx, deliveryID, eventName, event,
+		g.onProjectV2ItemEvent[ProjectItemEventRestoredAction],
+		g.onProjectV2ItemEvent[ProjectV2ItemEventAnyAction],
+	)
 }
 
 // OnProjectV2ItemEventAny registers callbacks listening to any events of type github.ProjectV2ItemEvent
@@ -710,29 +548,7 @@ func (g *EventHandler) handleProjectV2ItemEventAny(ctx context.Context, delivery
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onProjectV2ItemEvent[ProjectV2ItemEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onProjectV2ItemEvent[ProjectV2ItemEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.ProjectV2ItemEvent](ctx, deliveryID, eventName, event, g.onProjectV2ItemEvent[ProjectV2ItemEventAnyAction])
 }
 
 // ProjectV2ItemEvent handles github.ProjectV2ItemEvent.

--- a/githubevents/events_project_v2_item.go
+++ b/githubevents/events_project_v2_item.go
@@ -70,7 +70,7 @@ type ProjectV2ItemEventHandleFunc func(ctx context.Context, deliveryID string, e
 func (g *EventHandler) OnProjectItemEventCreated(callbacks ...ProjectV2ItemEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onProjectV2ItemEvent == nil {
@@ -95,7 +95,7 @@ func (g *EventHandler) OnProjectItemEventCreated(callbacks ...ProjectV2ItemEvent
 func (g *EventHandler) SetOnProjectItemEventCreated(callbacks ...ProjectV2ItemEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onProjectV2ItemEvent == nil {
@@ -156,7 +156,7 @@ func (g *EventHandler) handleProjectItemEventCreated(ctx context.Context, delive
 func (g *EventHandler) OnProjectItemEventEdited(callbacks ...ProjectV2ItemEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onProjectV2ItemEvent == nil {
@@ -181,7 +181,7 @@ func (g *EventHandler) OnProjectItemEventEdited(callbacks ...ProjectV2ItemEventH
 func (g *EventHandler) SetOnProjectItemEventEdited(callbacks ...ProjectV2ItemEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onProjectV2ItemEvent == nil {
@@ -242,7 +242,7 @@ func (g *EventHandler) handleProjectItemEventEdited(ctx context.Context, deliver
 func (g *EventHandler) OnProjectItemEventClosed(callbacks ...ProjectV2ItemEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onProjectV2ItemEvent == nil {
@@ -267,7 +267,7 @@ func (g *EventHandler) OnProjectItemEventClosed(callbacks ...ProjectV2ItemEventH
 func (g *EventHandler) SetOnProjectItemEventClosed(callbacks ...ProjectV2ItemEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onProjectV2ItemEvent == nil {
@@ -328,7 +328,7 @@ func (g *EventHandler) handleProjectItemEventClosed(ctx context.Context, deliver
 func (g *EventHandler) OnProjectItemEventReopened(callbacks ...ProjectV2ItemEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onProjectV2ItemEvent == nil {
@@ -353,7 +353,7 @@ func (g *EventHandler) OnProjectItemEventReopened(callbacks ...ProjectV2ItemEven
 func (g *EventHandler) SetOnProjectItemEventReopened(callbacks ...ProjectV2ItemEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onProjectV2ItemEvent == nil {
@@ -414,7 +414,7 @@ func (g *EventHandler) handleProjectItemEventReopened(ctx context.Context, deliv
 func (g *EventHandler) OnProjectItemEventDeleted(callbacks ...ProjectV2ItemEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onProjectV2ItemEvent == nil {
@@ -439,7 +439,7 @@ func (g *EventHandler) OnProjectItemEventDeleted(callbacks ...ProjectV2ItemEvent
 func (g *EventHandler) SetOnProjectItemEventDeleted(callbacks ...ProjectV2ItemEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onProjectV2ItemEvent == nil {
@@ -500,7 +500,7 @@ func (g *EventHandler) handleProjectItemEventDeleted(ctx context.Context, delive
 func (g *EventHandler) OnProjectItemEventConverted(callbacks ...ProjectV2ItemEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onProjectV2ItemEvent == nil {
@@ -525,7 +525,7 @@ func (g *EventHandler) OnProjectItemEventConverted(callbacks ...ProjectV2ItemEve
 func (g *EventHandler) SetOnProjectItemEventConverted(callbacks ...ProjectV2ItemEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onProjectV2ItemEvent == nil {
@@ -586,7 +586,7 @@ func (g *EventHandler) handleProjectItemEventConverted(ctx context.Context, deli
 func (g *EventHandler) OnProjectItemEventRestored(callbacks ...ProjectV2ItemEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onProjectV2ItemEvent == nil {
@@ -611,7 +611,7 @@ func (g *EventHandler) OnProjectItemEventRestored(callbacks ...ProjectV2ItemEven
 func (g *EventHandler) SetOnProjectItemEventRestored(callbacks ...ProjectV2ItemEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onProjectV2ItemEvent == nil {
@@ -672,7 +672,7 @@ func (g *EventHandler) handleProjectItemEventRestored(ctx context.Context, deliv
 func (g *EventHandler) OnProjectV2ItemEventAny(callbacks ...ProjectV2ItemEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onProjectV2ItemEvent == nil {
@@ -697,7 +697,7 @@ func (g *EventHandler) OnProjectV2ItemEventAny(callbacks ...ProjectV2ItemEventHa
 func (g *EventHandler) SetOnProjectV2ItemEventAny(callbacks ...ProjectV2ItemEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onProjectV2ItemEvent == nil {

--- a/githubevents/events_public.go
+++ b/githubevents/events_public.go
@@ -42,7 +42,7 @@ type PublicEventHandleFunc func(ctx context.Context, deliveryID string, eventNam
 func (g *EventHandler) OnPublicEventAny(callbacks ...PublicEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPublicEvent == nil {
@@ -67,7 +67,7 @@ func (g *EventHandler) OnPublicEventAny(callbacks ...PublicEventHandleFunc) {
 func (g *EventHandler) SetOnPublicEventAny(callbacks ...PublicEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPublicEvent == nil {

--- a/githubevents/events_public.go
+++ b/githubevents/events_public.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -80,29 +79,7 @@ func (g *EventHandler) handlePublicEventAny(ctx context.Context, deliveryID stri
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onPublicEvent[PublicEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onPublicEvent[PublicEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PublicEvent](ctx, deliveryID, eventName, event, g.onPublicEvent[PublicEventAnyAction])
 }
 
 // PublicEvent handles github.PublicEvent.

--- a/githubevents/events_pull_request.go
+++ b/githubevents/events_pull_request.go
@@ -110,7 +110,7 @@ type PullRequestEventHandleFunc func(ctx context.Context, deliveryID string, eve
 func (g *EventHandler) OnPullRequestEventAssigned(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -135,7 +135,7 @@ func (g *EventHandler) OnPullRequestEventAssigned(callbacks ...PullRequestEventH
 func (g *EventHandler) SetOnPullRequestEventAssigned(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -196,7 +196,7 @@ func (g *EventHandler) handlePullRequestEventAssigned(ctx context.Context, deliv
 func (g *EventHandler) OnPullRequestEventAutoMergeDisabled(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -221,7 +221,7 @@ func (g *EventHandler) OnPullRequestEventAutoMergeDisabled(callbacks ...PullRequ
 func (g *EventHandler) SetOnPullRequestEventAutoMergeDisabled(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -282,7 +282,7 @@ func (g *EventHandler) handlePullRequestEventAutoMergeDisabled(ctx context.Conte
 func (g *EventHandler) OnPullRequestEventAutoMergeEnabled(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -307,7 +307,7 @@ func (g *EventHandler) OnPullRequestEventAutoMergeEnabled(callbacks ...PullReque
 func (g *EventHandler) SetOnPullRequestEventAutoMergeEnabled(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -368,7 +368,7 @@ func (g *EventHandler) handlePullRequestEventAutoMergeEnabled(ctx context.Contex
 func (g *EventHandler) OnPullRequestEventClosed(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -393,7 +393,7 @@ func (g *EventHandler) OnPullRequestEventClosed(callbacks ...PullRequestEventHan
 func (g *EventHandler) SetOnPullRequestEventClosed(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -454,7 +454,7 @@ func (g *EventHandler) handlePullRequestEventClosed(ctx context.Context, deliver
 func (g *EventHandler) OnPullRequestEventConvertedToDraft(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -479,7 +479,7 @@ func (g *EventHandler) OnPullRequestEventConvertedToDraft(callbacks ...PullReque
 func (g *EventHandler) SetOnPullRequestEventConvertedToDraft(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -540,7 +540,7 @@ func (g *EventHandler) handlePullRequestEventConvertedToDraft(ctx context.Contex
 func (g *EventHandler) OnPullRequestEventEdited(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -565,7 +565,7 @@ func (g *EventHandler) OnPullRequestEventEdited(callbacks ...PullRequestEventHan
 func (g *EventHandler) SetOnPullRequestEventEdited(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -626,7 +626,7 @@ func (g *EventHandler) handlePullRequestEventEdited(ctx context.Context, deliver
 func (g *EventHandler) OnPullRequestEventLabeled(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -651,7 +651,7 @@ func (g *EventHandler) OnPullRequestEventLabeled(callbacks ...PullRequestEventHa
 func (g *EventHandler) SetOnPullRequestEventLabeled(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -712,7 +712,7 @@ func (g *EventHandler) handlePullRequestEventLabeled(ctx context.Context, delive
 func (g *EventHandler) OnPullRequestEventLocked(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -737,7 +737,7 @@ func (g *EventHandler) OnPullRequestEventLocked(callbacks ...PullRequestEventHan
 func (g *EventHandler) SetOnPullRequestEventLocked(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -798,7 +798,7 @@ func (g *EventHandler) handlePullRequestEventLocked(ctx context.Context, deliver
 func (g *EventHandler) OnPullRequestEventOpened(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -823,7 +823,7 @@ func (g *EventHandler) OnPullRequestEventOpened(callbacks ...PullRequestEventHan
 func (g *EventHandler) SetOnPullRequestEventOpened(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -884,7 +884,7 @@ func (g *EventHandler) handlePullRequestEventOpened(ctx context.Context, deliver
 func (g *EventHandler) OnPullRequestEventReadyForReview(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -909,7 +909,7 @@ func (g *EventHandler) OnPullRequestEventReadyForReview(callbacks ...PullRequest
 func (g *EventHandler) SetOnPullRequestEventReadyForReview(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -970,7 +970,7 @@ func (g *EventHandler) handlePullRequestEventReadyForReview(ctx context.Context,
 func (g *EventHandler) OnPullRequestEventReopened(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -995,7 +995,7 @@ func (g *EventHandler) OnPullRequestEventReopened(callbacks ...PullRequestEventH
 func (g *EventHandler) SetOnPullRequestEventReopened(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -1056,7 +1056,7 @@ func (g *EventHandler) handlePullRequestEventReopened(ctx context.Context, deliv
 func (g *EventHandler) OnPullRequestEventReviewRequestRemoved(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -1081,7 +1081,7 @@ func (g *EventHandler) OnPullRequestEventReviewRequestRemoved(callbacks ...PullR
 func (g *EventHandler) SetOnPullRequestEventReviewRequestRemoved(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -1142,7 +1142,7 @@ func (g *EventHandler) handlePullRequestEventReviewRequestRemoved(ctx context.Co
 func (g *EventHandler) OnPullRequestEventReviewRequested(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -1167,7 +1167,7 @@ func (g *EventHandler) OnPullRequestEventReviewRequested(callbacks ...PullReques
 func (g *EventHandler) SetOnPullRequestEventReviewRequested(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -1228,7 +1228,7 @@ func (g *EventHandler) handlePullRequestEventReviewRequested(ctx context.Context
 func (g *EventHandler) OnPullRequestEventSynchronize(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -1253,7 +1253,7 @@ func (g *EventHandler) OnPullRequestEventSynchronize(callbacks ...PullRequestEve
 func (g *EventHandler) SetOnPullRequestEventSynchronize(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -1314,7 +1314,7 @@ func (g *EventHandler) handlePullRequestEventSynchronize(ctx context.Context, de
 func (g *EventHandler) OnPullRequestEventUnassigned(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -1339,7 +1339,7 @@ func (g *EventHandler) OnPullRequestEventUnassigned(callbacks ...PullRequestEven
 func (g *EventHandler) SetOnPullRequestEventUnassigned(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -1400,7 +1400,7 @@ func (g *EventHandler) handlePullRequestEventUnassigned(ctx context.Context, del
 func (g *EventHandler) OnPullRequestEventUnlabeled(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -1425,7 +1425,7 @@ func (g *EventHandler) OnPullRequestEventUnlabeled(callbacks ...PullRequestEvent
 func (g *EventHandler) SetOnPullRequestEventUnlabeled(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -1486,7 +1486,7 @@ func (g *EventHandler) handlePullRequestEventUnlabeled(ctx context.Context, deli
 func (g *EventHandler) OnPullRequestEventUnlocked(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -1511,7 +1511,7 @@ func (g *EventHandler) OnPullRequestEventUnlocked(callbacks ...PullRequestEventH
 func (g *EventHandler) SetOnPullRequestEventUnlocked(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -1572,7 +1572,7 @@ func (g *EventHandler) handlePullRequestEventUnlocked(ctx context.Context, deliv
 func (g *EventHandler) OnPullRequestEventAny(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {
@@ -1597,7 +1597,7 @@ func (g *EventHandler) OnPullRequestEventAny(callbacks ...PullRequestEventHandle
 func (g *EventHandler) SetOnPullRequestEventAny(callbacks ...PullRequestEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestEvent == nil {

--- a/githubevents/events_pull_request.go
+++ b/githubevents/events_pull_request.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -155,33 +154,10 @@ func (g *EventHandler) handlePullRequestEventAssigned(ctx context.Context, deliv
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		PullRequestEventAssignedAction,
-		PullRequestEventAnyAction,
-	} {
-		if _, ok := g.onPullRequestEvent[action]; ok {
-			for _, h := range g.onPullRequestEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
+		g.onPullRequestEvent[PullRequestEventAssignedAction],
+		g.onPullRequestEvent[PullRequestEventAnyAction],
+	)
 }
 
 // OnPullRequestEventAutoMergeDisabled registers callbacks listening to events of type github.PullRequestEvent and action 'auto_merge_disabled'.
@@ -241,33 +217,10 @@ func (g *EventHandler) handlePullRequestEventAutoMergeDisabled(ctx context.Conte
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		PullRequestEventAutoMergeDisabledAction,
-		PullRequestEventAnyAction,
-	} {
-		if _, ok := g.onPullRequestEvent[action]; ok {
-			for _, h := range g.onPullRequestEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
+		g.onPullRequestEvent[PullRequestEventAutoMergeDisabledAction],
+		g.onPullRequestEvent[PullRequestEventAnyAction],
+	)
 }
 
 // OnPullRequestEventAutoMergeEnabled registers callbacks listening to events of type github.PullRequestEvent and action 'auto_merge_enabled'.
@@ -327,33 +280,10 @@ func (g *EventHandler) handlePullRequestEventAutoMergeEnabled(ctx context.Contex
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		PullRequestEventAutoMergeEnabledAction,
-		PullRequestEventAnyAction,
-	} {
-		if _, ok := g.onPullRequestEvent[action]; ok {
-			for _, h := range g.onPullRequestEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
+		g.onPullRequestEvent[PullRequestEventAutoMergeEnabledAction],
+		g.onPullRequestEvent[PullRequestEventAnyAction],
+	)
 }
 
 // OnPullRequestEventClosed registers callbacks listening to events of type github.PullRequestEvent and action 'closed'.
@@ -413,33 +343,10 @@ func (g *EventHandler) handlePullRequestEventClosed(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		PullRequestEventClosedAction,
-		PullRequestEventAnyAction,
-	} {
-		if _, ok := g.onPullRequestEvent[action]; ok {
-			for _, h := range g.onPullRequestEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
+		g.onPullRequestEvent[PullRequestEventClosedAction],
+		g.onPullRequestEvent[PullRequestEventAnyAction],
+	)
 }
 
 // OnPullRequestEventConvertedToDraft registers callbacks listening to events of type github.PullRequestEvent and action 'converted_to_draft'.
@@ -499,33 +406,10 @@ func (g *EventHandler) handlePullRequestEventConvertedToDraft(ctx context.Contex
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		PullRequestEventConvertedToDraftAction,
-		PullRequestEventAnyAction,
-	} {
-		if _, ok := g.onPullRequestEvent[action]; ok {
-			for _, h := range g.onPullRequestEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
+		g.onPullRequestEvent[PullRequestEventConvertedToDraftAction],
+		g.onPullRequestEvent[PullRequestEventAnyAction],
+	)
 }
 
 // OnPullRequestEventEdited registers callbacks listening to events of type github.PullRequestEvent and action 'edited'.
@@ -585,33 +469,10 @@ func (g *EventHandler) handlePullRequestEventEdited(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		PullRequestEventEditedAction,
-		PullRequestEventAnyAction,
-	} {
-		if _, ok := g.onPullRequestEvent[action]; ok {
-			for _, h := range g.onPullRequestEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
+		g.onPullRequestEvent[PullRequestEventEditedAction],
+		g.onPullRequestEvent[PullRequestEventAnyAction],
+	)
 }
 
 // OnPullRequestEventLabeled registers callbacks listening to events of type github.PullRequestEvent and action 'labeled'.
@@ -671,33 +532,10 @@ func (g *EventHandler) handlePullRequestEventLabeled(ctx context.Context, delive
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		PullRequestEventLabeledAction,
-		PullRequestEventAnyAction,
-	} {
-		if _, ok := g.onPullRequestEvent[action]; ok {
-			for _, h := range g.onPullRequestEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
+		g.onPullRequestEvent[PullRequestEventLabeledAction],
+		g.onPullRequestEvent[PullRequestEventAnyAction],
+	)
 }
 
 // OnPullRequestEventLocked registers callbacks listening to events of type github.PullRequestEvent and action 'locked'.
@@ -757,33 +595,10 @@ func (g *EventHandler) handlePullRequestEventLocked(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		PullRequestEventLockedAction,
-		PullRequestEventAnyAction,
-	} {
-		if _, ok := g.onPullRequestEvent[action]; ok {
-			for _, h := range g.onPullRequestEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
+		g.onPullRequestEvent[PullRequestEventLockedAction],
+		g.onPullRequestEvent[PullRequestEventAnyAction],
+	)
 }
 
 // OnPullRequestEventOpened registers callbacks listening to events of type github.PullRequestEvent and action 'opened'.
@@ -843,33 +658,10 @@ func (g *EventHandler) handlePullRequestEventOpened(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		PullRequestEventOpenedAction,
-		PullRequestEventAnyAction,
-	} {
-		if _, ok := g.onPullRequestEvent[action]; ok {
-			for _, h := range g.onPullRequestEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
+		g.onPullRequestEvent[PullRequestEventOpenedAction],
+		g.onPullRequestEvent[PullRequestEventAnyAction],
+	)
 }
 
 // OnPullRequestEventReadyForReview registers callbacks listening to events of type github.PullRequestEvent and action 'ready_for_review'.
@@ -929,33 +721,10 @@ func (g *EventHandler) handlePullRequestEventReadyForReview(ctx context.Context,
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		PullRequestEventReadyForReviewAction,
-		PullRequestEventAnyAction,
-	} {
-		if _, ok := g.onPullRequestEvent[action]; ok {
-			for _, h := range g.onPullRequestEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
+		g.onPullRequestEvent[PullRequestEventReadyForReviewAction],
+		g.onPullRequestEvent[PullRequestEventAnyAction],
+	)
 }
 
 // OnPullRequestEventReopened registers callbacks listening to events of type github.PullRequestEvent and action 'reopened'.
@@ -1015,33 +784,10 @@ func (g *EventHandler) handlePullRequestEventReopened(ctx context.Context, deliv
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		PullRequestEventReopenedAction,
-		PullRequestEventAnyAction,
-	} {
-		if _, ok := g.onPullRequestEvent[action]; ok {
-			for _, h := range g.onPullRequestEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
+		g.onPullRequestEvent[PullRequestEventReopenedAction],
+		g.onPullRequestEvent[PullRequestEventAnyAction],
+	)
 }
 
 // OnPullRequestEventReviewRequestRemoved registers callbacks listening to events of type github.PullRequestEvent and action 'review_request_removed'.
@@ -1101,33 +847,10 @@ func (g *EventHandler) handlePullRequestEventReviewRequestRemoved(ctx context.Co
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		PullRequestEventReviewRequestRemovedAction,
-		PullRequestEventAnyAction,
-	} {
-		if _, ok := g.onPullRequestEvent[action]; ok {
-			for _, h := range g.onPullRequestEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
+		g.onPullRequestEvent[PullRequestEventReviewRequestRemovedAction],
+		g.onPullRequestEvent[PullRequestEventAnyAction],
+	)
 }
 
 // OnPullRequestEventReviewRequested registers callbacks listening to events of type github.PullRequestEvent and action 'review_requested'.
@@ -1187,33 +910,10 @@ func (g *EventHandler) handlePullRequestEventReviewRequested(ctx context.Context
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		PullRequestEventReviewRequestedAction,
-		PullRequestEventAnyAction,
-	} {
-		if _, ok := g.onPullRequestEvent[action]; ok {
-			for _, h := range g.onPullRequestEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
+		g.onPullRequestEvent[PullRequestEventReviewRequestedAction],
+		g.onPullRequestEvent[PullRequestEventAnyAction],
+	)
 }
 
 // OnPullRequestEventSynchronize registers callbacks listening to events of type github.PullRequestEvent and action 'synchronize'.
@@ -1273,33 +973,10 @@ func (g *EventHandler) handlePullRequestEventSynchronize(ctx context.Context, de
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		PullRequestEventSynchronizeAction,
-		PullRequestEventAnyAction,
-	} {
-		if _, ok := g.onPullRequestEvent[action]; ok {
-			for _, h := range g.onPullRequestEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
+		g.onPullRequestEvent[PullRequestEventSynchronizeAction],
+		g.onPullRequestEvent[PullRequestEventAnyAction],
+	)
 }
 
 // OnPullRequestEventUnassigned registers callbacks listening to events of type github.PullRequestEvent and action 'unassigned'.
@@ -1359,33 +1036,10 @@ func (g *EventHandler) handlePullRequestEventUnassigned(ctx context.Context, del
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		PullRequestEventUnassignedAction,
-		PullRequestEventAnyAction,
-	} {
-		if _, ok := g.onPullRequestEvent[action]; ok {
-			for _, h := range g.onPullRequestEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
+		g.onPullRequestEvent[PullRequestEventUnassignedAction],
+		g.onPullRequestEvent[PullRequestEventAnyAction],
+	)
 }
 
 // OnPullRequestEventUnlabeled registers callbacks listening to events of type github.PullRequestEvent and action 'unlabeled'.
@@ -1445,33 +1099,10 @@ func (g *EventHandler) handlePullRequestEventUnlabeled(ctx context.Context, deli
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		PullRequestEventUnlabeledAction,
-		PullRequestEventAnyAction,
-	} {
-		if _, ok := g.onPullRequestEvent[action]; ok {
-			for _, h := range g.onPullRequestEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
+		g.onPullRequestEvent[PullRequestEventUnlabeledAction],
+		g.onPullRequestEvent[PullRequestEventAnyAction],
+	)
 }
 
 // OnPullRequestEventUnlocked registers callbacks listening to events of type github.PullRequestEvent and action 'unlocked'.
@@ -1531,33 +1162,10 @@ func (g *EventHandler) handlePullRequestEventUnlocked(ctx context.Context, deliv
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		PullRequestEventUnlockedAction,
-		PullRequestEventAnyAction,
-	} {
-		if _, ok := g.onPullRequestEvent[action]; ok {
-			for _, h := range g.onPullRequestEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
+		g.onPullRequestEvent[PullRequestEventUnlockedAction],
+		g.onPullRequestEvent[PullRequestEventAnyAction],
+	)
 }
 
 // OnPullRequestEventAny registers callbacks listening to any events of type github.PullRequestEvent
@@ -1610,29 +1218,7 @@ func (g *EventHandler) handlePullRequestEventAny(ctx context.Context, deliveryID
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onPullRequestEvent[PullRequestEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onPullRequestEvent[PullRequestEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event, g.onPullRequestEvent[PullRequestEventAnyAction])
 }
 
 // PullRequestEvent handles github.PullRequestEvent.

--- a/githubevents/events_pull_request_review.go
+++ b/githubevents/events_pull_request_review.go
@@ -54,7 +54,7 @@ type PullRequestReviewEventHandleFunc func(ctx context.Context, deliveryID strin
 func (g *EventHandler) OnPullRequestReviewEventSubmitted(callbacks ...PullRequestReviewEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestReviewEvent == nil {
@@ -79,7 +79,7 @@ func (g *EventHandler) OnPullRequestReviewEventSubmitted(callbacks ...PullReques
 func (g *EventHandler) SetOnPullRequestReviewEventSubmitted(callbacks ...PullRequestReviewEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestReviewEvent == nil {
@@ -140,7 +140,7 @@ func (g *EventHandler) handlePullRequestReviewEventSubmitted(ctx context.Context
 func (g *EventHandler) OnPullRequestReviewEventEdited(callbacks ...PullRequestReviewEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestReviewEvent == nil {
@@ -165,7 +165,7 @@ func (g *EventHandler) OnPullRequestReviewEventEdited(callbacks ...PullRequestRe
 func (g *EventHandler) SetOnPullRequestReviewEventEdited(callbacks ...PullRequestReviewEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestReviewEvent == nil {
@@ -226,7 +226,7 @@ func (g *EventHandler) handlePullRequestReviewEventEdited(ctx context.Context, d
 func (g *EventHandler) OnPullRequestReviewEventDismissed(callbacks ...PullRequestReviewEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestReviewEvent == nil {
@@ -251,7 +251,7 @@ func (g *EventHandler) OnPullRequestReviewEventDismissed(callbacks ...PullReques
 func (g *EventHandler) SetOnPullRequestReviewEventDismissed(callbacks ...PullRequestReviewEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestReviewEvent == nil {
@@ -312,7 +312,7 @@ func (g *EventHandler) handlePullRequestReviewEventDismissed(ctx context.Context
 func (g *EventHandler) OnPullRequestReviewEventAny(callbacks ...PullRequestReviewEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestReviewEvent == nil {
@@ -337,7 +337,7 @@ func (g *EventHandler) OnPullRequestReviewEventAny(callbacks ...PullRequestRevie
 func (g *EventHandler) SetOnPullRequestReviewEventAny(callbacks ...PullRequestReviewEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestReviewEvent == nil {

--- a/githubevents/events_pull_request_review.go
+++ b/githubevents/events_pull_request_review.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -99,33 +98,10 @@ func (g *EventHandler) handlePullRequestReviewEventSubmitted(ctx context.Context
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		PullRequestReviewEventSubmittedAction,
-		PullRequestReviewEventAnyAction,
-	} {
-		if _, ok := g.onPullRequestReviewEvent[action]; ok {
-			for _, h := range g.onPullRequestReviewEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PullRequestReviewEvent](ctx, deliveryID, eventName, event,
+		g.onPullRequestReviewEvent[PullRequestReviewEventSubmittedAction],
+		g.onPullRequestReviewEvent[PullRequestReviewEventAnyAction],
+	)
 }
 
 // OnPullRequestReviewEventEdited registers callbacks listening to events of type github.PullRequestReviewEvent and action 'edited'.
@@ -185,33 +161,10 @@ func (g *EventHandler) handlePullRequestReviewEventEdited(ctx context.Context, d
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		PullRequestReviewEventEditedAction,
-		PullRequestReviewEventAnyAction,
-	} {
-		if _, ok := g.onPullRequestReviewEvent[action]; ok {
-			for _, h := range g.onPullRequestReviewEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PullRequestReviewEvent](ctx, deliveryID, eventName, event,
+		g.onPullRequestReviewEvent[PullRequestReviewEventEditedAction],
+		g.onPullRequestReviewEvent[PullRequestReviewEventAnyAction],
+	)
 }
 
 // OnPullRequestReviewEventDismissed registers callbacks listening to events of type github.PullRequestReviewEvent and action 'dismissed'.
@@ -271,33 +224,10 @@ func (g *EventHandler) handlePullRequestReviewEventDismissed(ctx context.Context
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		PullRequestReviewEventDismissedAction,
-		PullRequestReviewEventAnyAction,
-	} {
-		if _, ok := g.onPullRequestReviewEvent[action]; ok {
-			for _, h := range g.onPullRequestReviewEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PullRequestReviewEvent](ctx, deliveryID, eventName, event,
+		g.onPullRequestReviewEvent[PullRequestReviewEventDismissedAction],
+		g.onPullRequestReviewEvent[PullRequestReviewEventAnyAction],
+	)
 }
 
 // OnPullRequestReviewEventAny registers callbacks listening to any events of type github.PullRequestReviewEvent
@@ -350,29 +280,7 @@ func (g *EventHandler) handlePullRequestReviewEventAny(ctx context.Context, deli
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onPullRequestReviewEvent[PullRequestReviewEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onPullRequestReviewEvent[PullRequestReviewEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PullRequestReviewEvent](ctx, deliveryID, eventName, event, g.onPullRequestReviewEvent[PullRequestReviewEventAnyAction])
 }
 
 // PullRequestReviewEvent handles github.PullRequestReviewEvent.

--- a/githubevents/events_pull_request_review_comment.go
+++ b/githubevents/events_pull_request_review_comment.go
@@ -54,7 +54,7 @@ type PullRequestReviewCommentEventHandleFunc func(ctx context.Context, deliveryI
 func (g *EventHandler) OnPullRequestReviewCommentEventCreated(callbacks ...PullRequestReviewCommentEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestReviewCommentEvent == nil {
@@ -79,7 +79,7 @@ func (g *EventHandler) OnPullRequestReviewCommentEventCreated(callbacks ...PullR
 func (g *EventHandler) SetOnPullRequestReviewCommentEventCreated(callbacks ...PullRequestReviewCommentEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestReviewCommentEvent == nil {
@@ -140,7 +140,7 @@ func (g *EventHandler) handlePullRequestReviewCommentEventCreated(ctx context.Co
 func (g *EventHandler) OnPullRequestReviewCommentEventEdited(callbacks ...PullRequestReviewCommentEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestReviewCommentEvent == nil {
@@ -165,7 +165,7 @@ func (g *EventHandler) OnPullRequestReviewCommentEventEdited(callbacks ...PullRe
 func (g *EventHandler) SetOnPullRequestReviewCommentEventEdited(callbacks ...PullRequestReviewCommentEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestReviewCommentEvent == nil {
@@ -226,7 +226,7 @@ func (g *EventHandler) handlePullRequestReviewCommentEventEdited(ctx context.Con
 func (g *EventHandler) OnPullRequestReviewCommentEventDeleted(callbacks ...PullRequestReviewCommentEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestReviewCommentEvent == nil {
@@ -251,7 +251,7 @@ func (g *EventHandler) OnPullRequestReviewCommentEventDeleted(callbacks ...PullR
 func (g *EventHandler) SetOnPullRequestReviewCommentEventDeleted(callbacks ...PullRequestReviewCommentEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestReviewCommentEvent == nil {
@@ -312,7 +312,7 @@ func (g *EventHandler) handlePullRequestReviewCommentEventDeleted(ctx context.Co
 func (g *EventHandler) OnPullRequestReviewCommentEventAny(callbacks ...PullRequestReviewCommentEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestReviewCommentEvent == nil {
@@ -337,7 +337,7 @@ func (g *EventHandler) OnPullRequestReviewCommentEventAny(callbacks ...PullReque
 func (g *EventHandler) SetOnPullRequestReviewCommentEventAny(callbacks ...PullRequestReviewCommentEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPullRequestReviewCommentEvent == nil {

--- a/githubevents/events_pull_request_review_comment.go
+++ b/githubevents/events_pull_request_review_comment.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -99,33 +98,10 @@ func (g *EventHandler) handlePullRequestReviewCommentEventCreated(ctx context.Co
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		PullRequestReviewCommentEventCreatedAction,
-		PullRequestReviewCommentEventAnyAction,
-	} {
-		if _, ok := g.onPullRequestReviewCommentEvent[action]; ok {
-			for _, h := range g.onPullRequestReviewCommentEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PullRequestReviewCommentEvent](ctx, deliveryID, eventName, event,
+		g.onPullRequestReviewCommentEvent[PullRequestReviewCommentEventCreatedAction],
+		g.onPullRequestReviewCommentEvent[PullRequestReviewCommentEventAnyAction],
+	)
 }
 
 // OnPullRequestReviewCommentEventEdited registers callbacks listening to events of type github.PullRequestReviewCommentEvent and action 'edited'.
@@ -185,33 +161,10 @@ func (g *EventHandler) handlePullRequestReviewCommentEventEdited(ctx context.Con
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		PullRequestReviewCommentEventEditedAction,
-		PullRequestReviewCommentEventAnyAction,
-	} {
-		if _, ok := g.onPullRequestReviewCommentEvent[action]; ok {
-			for _, h := range g.onPullRequestReviewCommentEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PullRequestReviewCommentEvent](ctx, deliveryID, eventName, event,
+		g.onPullRequestReviewCommentEvent[PullRequestReviewCommentEventEditedAction],
+		g.onPullRequestReviewCommentEvent[PullRequestReviewCommentEventAnyAction],
+	)
 }
 
 // OnPullRequestReviewCommentEventDeleted registers callbacks listening to events of type github.PullRequestReviewCommentEvent and action 'deleted'.
@@ -271,33 +224,10 @@ func (g *EventHandler) handlePullRequestReviewCommentEventDeleted(ctx context.Co
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		PullRequestReviewCommentEventDeletedAction,
-		PullRequestReviewCommentEventAnyAction,
-	} {
-		if _, ok := g.onPullRequestReviewCommentEvent[action]; ok {
-			for _, h := range g.onPullRequestReviewCommentEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PullRequestReviewCommentEvent](ctx, deliveryID, eventName, event,
+		g.onPullRequestReviewCommentEvent[PullRequestReviewCommentEventDeletedAction],
+		g.onPullRequestReviewCommentEvent[PullRequestReviewCommentEventAnyAction],
+	)
 }
 
 // OnPullRequestReviewCommentEventAny registers callbacks listening to any events of type github.PullRequestReviewCommentEvent
@@ -350,29 +280,7 @@ func (g *EventHandler) handlePullRequestReviewCommentEventAny(ctx context.Contex
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onPullRequestReviewCommentEvent[PullRequestReviewCommentEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onPullRequestReviewCommentEvent[PullRequestReviewCommentEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PullRequestReviewCommentEvent](ctx, deliveryID, eventName, event, g.onPullRequestReviewCommentEvent[PullRequestReviewCommentEventAnyAction])
 }
 
 // PullRequestReviewCommentEvent handles github.PullRequestReviewCommentEvent.

--- a/githubevents/events_push.go
+++ b/githubevents/events_push.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -80,29 +79,7 @@ func (g *EventHandler) handlePushEventAny(ctx context.Context, deliveryID string
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onPushEvent[PushEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onPushEvent[PushEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.PushEvent](ctx, deliveryID, eventName, event, g.onPushEvent[PushEventAnyAction])
 }
 
 // PushEvent handles github.PushEvent.

--- a/githubevents/events_push.go
+++ b/githubevents/events_push.go
@@ -42,7 +42,7 @@ type PushEventHandleFunc func(ctx context.Context, deliveryID string, eventName 
 func (g *EventHandler) OnPushEventAny(callbacks ...PushEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPushEvent == nil {
@@ -67,7 +67,7 @@ func (g *EventHandler) OnPushEventAny(callbacks ...PushEventHandleFunc) {
 func (g *EventHandler) SetOnPushEventAny(callbacks ...PushEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onPushEvent == nil {

--- a/githubevents/events_release.go
+++ b/githubevents/events_release.go
@@ -70,7 +70,7 @@ type ReleaseEventHandleFunc func(ctx context.Context, deliveryID string, eventNa
 func (g *EventHandler) OnReleaseEventPublished(callbacks ...ReleaseEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onReleaseEvent == nil {
@@ -95,7 +95,7 @@ func (g *EventHandler) OnReleaseEventPublished(callbacks ...ReleaseEventHandleFu
 func (g *EventHandler) SetOnReleaseEventPublished(callbacks ...ReleaseEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onReleaseEvent == nil {
@@ -156,7 +156,7 @@ func (g *EventHandler) handleReleaseEventPublished(ctx context.Context, delivery
 func (g *EventHandler) OnReleaseEventUnpublished(callbacks ...ReleaseEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onReleaseEvent == nil {
@@ -181,7 +181,7 @@ func (g *EventHandler) OnReleaseEventUnpublished(callbacks ...ReleaseEventHandle
 func (g *EventHandler) SetOnReleaseEventUnpublished(callbacks ...ReleaseEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onReleaseEvent == nil {
@@ -242,7 +242,7 @@ func (g *EventHandler) handleReleaseEventUnpublished(ctx context.Context, delive
 func (g *EventHandler) OnReleaseEventCreated(callbacks ...ReleaseEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onReleaseEvent == nil {
@@ -267,7 +267,7 @@ func (g *EventHandler) OnReleaseEventCreated(callbacks ...ReleaseEventHandleFunc
 func (g *EventHandler) SetOnReleaseEventCreated(callbacks ...ReleaseEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onReleaseEvent == nil {
@@ -328,7 +328,7 @@ func (g *EventHandler) handleReleaseEventCreated(ctx context.Context, deliveryID
 func (g *EventHandler) OnReleaseEventEdited(callbacks ...ReleaseEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onReleaseEvent == nil {
@@ -353,7 +353,7 @@ func (g *EventHandler) OnReleaseEventEdited(callbacks ...ReleaseEventHandleFunc)
 func (g *EventHandler) SetOnReleaseEventEdited(callbacks ...ReleaseEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onReleaseEvent == nil {
@@ -414,7 +414,7 @@ func (g *EventHandler) handleReleaseEventEdited(ctx context.Context, deliveryID 
 func (g *EventHandler) OnReleaseEventDeleted(callbacks ...ReleaseEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onReleaseEvent == nil {
@@ -439,7 +439,7 @@ func (g *EventHandler) OnReleaseEventDeleted(callbacks ...ReleaseEventHandleFunc
 func (g *EventHandler) SetOnReleaseEventDeleted(callbacks ...ReleaseEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onReleaseEvent == nil {
@@ -500,7 +500,7 @@ func (g *EventHandler) handleReleaseEventDeleted(ctx context.Context, deliveryID
 func (g *EventHandler) OnReleaseEventPreReleased(callbacks ...ReleaseEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onReleaseEvent == nil {
@@ -525,7 +525,7 @@ func (g *EventHandler) OnReleaseEventPreReleased(callbacks ...ReleaseEventHandle
 func (g *EventHandler) SetOnReleaseEventPreReleased(callbacks ...ReleaseEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onReleaseEvent == nil {
@@ -586,7 +586,7 @@ func (g *EventHandler) handleReleaseEventPreReleased(ctx context.Context, delive
 func (g *EventHandler) OnReleaseEventReleased(callbacks ...ReleaseEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onReleaseEvent == nil {
@@ -611,7 +611,7 @@ func (g *EventHandler) OnReleaseEventReleased(callbacks ...ReleaseEventHandleFun
 func (g *EventHandler) SetOnReleaseEventReleased(callbacks ...ReleaseEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onReleaseEvent == nil {
@@ -672,7 +672,7 @@ func (g *EventHandler) handleReleaseEventReleased(ctx context.Context, deliveryI
 func (g *EventHandler) OnReleaseEventAny(callbacks ...ReleaseEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onReleaseEvent == nil {
@@ -697,7 +697,7 @@ func (g *EventHandler) OnReleaseEventAny(callbacks ...ReleaseEventHandleFunc) {
 func (g *EventHandler) SetOnReleaseEventAny(callbacks ...ReleaseEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onReleaseEvent == nil {

--- a/githubevents/events_release.go
+++ b/githubevents/events_release.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -115,33 +114,10 @@ func (g *EventHandler) handleReleaseEventPublished(ctx context.Context, delivery
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		ReleaseEventPublishedAction,
-		ReleaseEventAnyAction,
-	} {
-		if _, ok := g.onReleaseEvent[action]; ok {
-			for _, h := range g.onReleaseEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.ReleaseEvent](ctx, deliveryID, eventName, event,
+		g.onReleaseEvent[ReleaseEventPublishedAction],
+		g.onReleaseEvent[ReleaseEventAnyAction],
+	)
 }
 
 // OnReleaseEventUnpublished registers callbacks listening to events of type github.ReleaseEvent and action 'unpublished'.
@@ -201,33 +177,10 @@ func (g *EventHandler) handleReleaseEventUnpublished(ctx context.Context, delive
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		ReleaseEventUnpublishedAction,
-		ReleaseEventAnyAction,
-	} {
-		if _, ok := g.onReleaseEvent[action]; ok {
-			for _, h := range g.onReleaseEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.ReleaseEvent](ctx, deliveryID, eventName, event,
+		g.onReleaseEvent[ReleaseEventUnpublishedAction],
+		g.onReleaseEvent[ReleaseEventAnyAction],
+	)
 }
 
 // OnReleaseEventCreated registers callbacks listening to events of type github.ReleaseEvent and action 'created'.
@@ -287,33 +240,10 @@ func (g *EventHandler) handleReleaseEventCreated(ctx context.Context, deliveryID
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		ReleaseEventCreatedAction,
-		ReleaseEventAnyAction,
-	} {
-		if _, ok := g.onReleaseEvent[action]; ok {
-			for _, h := range g.onReleaseEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.ReleaseEvent](ctx, deliveryID, eventName, event,
+		g.onReleaseEvent[ReleaseEventCreatedAction],
+		g.onReleaseEvent[ReleaseEventAnyAction],
+	)
 }
 
 // OnReleaseEventEdited registers callbacks listening to events of type github.ReleaseEvent and action 'edited'.
@@ -373,33 +303,10 @@ func (g *EventHandler) handleReleaseEventEdited(ctx context.Context, deliveryID 
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		ReleaseEventEditedAction,
-		ReleaseEventAnyAction,
-	} {
-		if _, ok := g.onReleaseEvent[action]; ok {
-			for _, h := range g.onReleaseEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.ReleaseEvent](ctx, deliveryID, eventName, event,
+		g.onReleaseEvent[ReleaseEventEditedAction],
+		g.onReleaseEvent[ReleaseEventAnyAction],
+	)
 }
 
 // OnReleaseEventDeleted registers callbacks listening to events of type github.ReleaseEvent and action 'deleted'.
@@ -459,33 +366,10 @@ func (g *EventHandler) handleReleaseEventDeleted(ctx context.Context, deliveryID
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		ReleaseEventDeletedAction,
-		ReleaseEventAnyAction,
-	} {
-		if _, ok := g.onReleaseEvent[action]; ok {
-			for _, h := range g.onReleaseEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.ReleaseEvent](ctx, deliveryID, eventName, event,
+		g.onReleaseEvent[ReleaseEventDeletedAction],
+		g.onReleaseEvent[ReleaseEventAnyAction],
+	)
 }
 
 // OnReleaseEventPreReleased registers callbacks listening to events of type github.ReleaseEvent and action 'prereleased'.
@@ -545,33 +429,10 @@ func (g *EventHandler) handleReleaseEventPreReleased(ctx context.Context, delive
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		ReleaseEventPreReleasedAction,
-		ReleaseEventAnyAction,
-	} {
-		if _, ok := g.onReleaseEvent[action]; ok {
-			for _, h := range g.onReleaseEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.ReleaseEvent](ctx, deliveryID, eventName, event,
+		g.onReleaseEvent[ReleaseEventPreReleasedAction],
+		g.onReleaseEvent[ReleaseEventAnyAction],
+	)
 }
 
 // OnReleaseEventReleased registers callbacks listening to events of type github.ReleaseEvent and action 'released'.
@@ -631,33 +492,10 @@ func (g *EventHandler) handleReleaseEventReleased(ctx context.Context, deliveryI
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		ReleaseEventReleasedAction,
-		ReleaseEventAnyAction,
-	} {
-		if _, ok := g.onReleaseEvent[action]; ok {
-			for _, h := range g.onReleaseEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.ReleaseEvent](ctx, deliveryID, eventName, event,
+		g.onReleaseEvent[ReleaseEventReleasedAction],
+		g.onReleaseEvent[ReleaseEventAnyAction],
+	)
 }
 
 // OnReleaseEventAny registers callbacks listening to any events of type github.ReleaseEvent
@@ -710,29 +548,7 @@ func (g *EventHandler) handleReleaseEventAny(ctx context.Context, deliveryID str
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onReleaseEvent[ReleaseEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onReleaseEvent[ReleaseEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.ReleaseEvent](ctx, deliveryID, eventName, event, g.onReleaseEvent[ReleaseEventAnyAction])
 }
 
 // ReleaseEvent handles github.ReleaseEvent.

--- a/githubevents/events_repository.go
+++ b/githubevents/events_repository.go
@@ -78,7 +78,7 @@ type RepositoryEventHandleFunc func(ctx context.Context, deliveryID string, even
 func (g *EventHandler) OnRepositoryEventCreated(callbacks ...RepositoryEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryEvent == nil {
@@ -103,7 +103,7 @@ func (g *EventHandler) OnRepositoryEventCreated(callbacks ...RepositoryEventHand
 func (g *EventHandler) SetOnRepositoryEventCreated(callbacks ...RepositoryEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryEvent == nil {
@@ -164,7 +164,7 @@ func (g *EventHandler) handleRepositoryEventCreated(ctx context.Context, deliver
 func (g *EventHandler) OnRepositoryEventDeleted(callbacks ...RepositoryEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryEvent == nil {
@@ -189,7 +189,7 @@ func (g *EventHandler) OnRepositoryEventDeleted(callbacks ...RepositoryEventHand
 func (g *EventHandler) SetOnRepositoryEventDeleted(callbacks ...RepositoryEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryEvent == nil {
@@ -250,7 +250,7 @@ func (g *EventHandler) handleRepositoryEventDeleted(ctx context.Context, deliver
 func (g *EventHandler) OnRepositoryEventArchived(callbacks ...RepositoryEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryEvent == nil {
@@ -275,7 +275,7 @@ func (g *EventHandler) OnRepositoryEventArchived(callbacks ...RepositoryEventHan
 func (g *EventHandler) SetOnRepositoryEventArchived(callbacks ...RepositoryEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryEvent == nil {
@@ -336,7 +336,7 @@ func (g *EventHandler) handleRepositoryEventArchived(ctx context.Context, delive
 func (g *EventHandler) OnRepositoryEventUnarchived(callbacks ...RepositoryEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryEvent == nil {
@@ -361,7 +361,7 @@ func (g *EventHandler) OnRepositoryEventUnarchived(callbacks ...RepositoryEventH
 func (g *EventHandler) SetOnRepositoryEventUnarchived(callbacks ...RepositoryEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryEvent == nil {
@@ -422,7 +422,7 @@ func (g *EventHandler) handleRepositoryEventUnarchived(ctx context.Context, deli
 func (g *EventHandler) OnRepositoryEventEdited(callbacks ...RepositoryEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryEvent == nil {
@@ -447,7 +447,7 @@ func (g *EventHandler) OnRepositoryEventEdited(callbacks ...RepositoryEventHandl
 func (g *EventHandler) SetOnRepositoryEventEdited(callbacks ...RepositoryEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryEvent == nil {
@@ -508,7 +508,7 @@ func (g *EventHandler) handleRepositoryEventEdited(ctx context.Context, delivery
 func (g *EventHandler) OnRepositoryEventRenamed(callbacks ...RepositoryEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryEvent == nil {
@@ -533,7 +533,7 @@ func (g *EventHandler) OnRepositoryEventRenamed(callbacks ...RepositoryEventHand
 func (g *EventHandler) SetOnRepositoryEventRenamed(callbacks ...RepositoryEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryEvent == nil {
@@ -594,7 +594,7 @@ func (g *EventHandler) handleRepositoryEventRenamed(ctx context.Context, deliver
 func (g *EventHandler) OnRepositoryEventTransferred(callbacks ...RepositoryEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryEvent == nil {
@@ -619,7 +619,7 @@ func (g *EventHandler) OnRepositoryEventTransferred(callbacks ...RepositoryEvent
 func (g *EventHandler) SetOnRepositoryEventTransferred(callbacks ...RepositoryEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryEvent == nil {
@@ -680,7 +680,7 @@ func (g *EventHandler) handleRepositoryEventTransferred(ctx context.Context, del
 func (g *EventHandler) OnRepositoryEventPublicized(callbacks ...RepositoryEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryEvent == nil {
@@ -705,7 +705,7 @@ func (g *EventHandler) OnRepositoryEventPublicized(callbacks ...RepositoryEventH
 func (g *EventHandler) SetOnRepositoryEventPublicized(callbacks ...RepositoryEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryEvent == nil {
@@ -766,7 +766,7 @@ func (g *EventHandler) handleRepositoryEventPublicized(ctx context.Context, deli
 func (g *EventHandler) OnRepositoryEventPrivatized(callbacks ...RepositoryEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryEvent == nil {
@@ -791,7 +791,7 @@ func (g *EventHandler) OnRepositoryEventPrivatized(callbacks ...RepositoryEventH
 func (g *EventHandler) SetOnRepositoryEventPrivatized(callbacks ...RepositoryEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryEvent == nil {
@@ -852,7 +852,7 @@ func (g *EventHandler) handleRepositoryEventPrivatized(ctx context.Context, deli
 func (g *EventHandler) OnRepositoryEventAny(callbacks ...RepositoryEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryEvent == nil {
@@ -877,7 +877,7 @@ func (g *EventHandler) OnRepositoryEventAny(callbacks ...RepositoryEventHandleFu
 func (g *EventHandler) SetOnRepositoryEventAny(callbacks ...RepositoryEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryEvent == nil {

--- a/githubevents/events_repository.go
+++ b/githubevents/events_repository.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -123,33 +122,10 @@ func (g *EventHandler) handleRepositoryEventCreated(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		RepositoryEventCreatedAction,
-		RepositoryEventAnyAction,
-	} {
-		if _, ok := g.onRepositoryEvent[action]; ok {
-			for _, h := range g.onRepositoryEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event,
+		g.onRepositoryEvent[RepositoryEventCreatedAction],
+		g.onRepositoryEvent[RepositoryEventAnyAction],
+	)
 }
 
 // OnRepositoryEventDeleted registers callbacks listening to events of type github.RepositoryEvent and action 'deleted'.
@@ -209,33 +185,10 @@ func (g *EventHandler) handleRepositoryEventDeleted(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		RepositoryEventDeletedAction,
-		RepositoryEventAnyAction,
-	} {
-		if _, ok := g.onRepositoryEvent[action]; ok {
-			for _, h := range g.onRepositoryEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event,
+		g.onRepositoryEvent[RepositoryEventDeletedAction],
+		g.onRepositoryEvent[RepositoryEventAnyAction],
+	)
 }
 
 // OnRepositoryEventArchived registers callbacks listening to events of type github.RepositoryEvent and action 'archived'.
@@ -295,33 +248,10 @@ func (g *EventHandler) handleRepositoryEventArchived(ctx context.Context, delive
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		RepositoryEventArchivedAction,
-		RepositoryEventAnyAction,
-	} {
-		if _, ok := g.onRepositoryEvent[action]; ok {
-			for _, h := range g.onRepositoryEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event,
+		g.onRepositoryEvent[RepositoryEventArchivedAction],
+		g.onRepositoryEvent[RepositoryEventAnyAction],
+	)
 }
 
 // OnRepositoryEventUnarchived registers callbacks listening to events of type github.RepositoryEvent and action 'unarchived'.
@@ -381,33 +311,10 @@ func (g *EventHandler) handleRepositoryEventUnarchived(ctx context.Context, deli
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		RepositoryEventUnarchivedAction,
-		RepositoryEventAnyAction,
-	} {
-		if _, ok := g.onRepositoryEvent[action]; ok {
-			for _, h := range g.onRepositoryEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event,
+		g.onRepositoryEvent[RepositoryEventUnarchivedAction],
+		g.onRepositoryEvent[RepositoryEventAnyAction],
+	)
 }
 
 // OnRepositoryEventEdited registers callbacks listening to events of type github.RepositoryEvent and action 'edited'.
@@ -467,33 +374,10 @@ func (g *EventHandler) handleRepositoryEventEdited(ctx context.Context, delivery
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		RepositoryEventEditedAction,
-		RepositoryEventAnyAction,
-	} {
-		if _, ok := g.onRepositoryEvent[action]; ok {
-			for _, h := range g.onRepositoryEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event,
+		g.onRepositoryEvent[RepositoryEventEditedAction],
+		g.onRepositoryEvent[RepositoryEventAnyAction],
+	)
 }
 
 // OnRepositoryEventRenamed registers callbacks listening to events of type github.RepositoryEvent and action 'renamed'.
@@ -553,33 +437,10 @@ func (g *EventHandler) handleRepositoryEventRenamed(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		RepositoryEventRenamedAction,
-		RepositoryEventAnyAction,
-	} {
-		if _, ok := g.onRepositoryEvent[action]; ok {
-			for _, h := range g.onRepositoryEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event,
+		g.onRepositoryEvent[RepositoryEventRenamedAction],
+		g.onRepositoryEvent[RepositoryEventAnyAction],
+	)
 }
 
 // OnRepositoryEventTransferred registers callbacks listening to events of type github.RepositoryEvent and action 'transferred'.
@@ -639,33 +500,10 @@ func (g *EventHandler) handleRepositoryEventTransferred(ctx context.Context, del
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		RepositoryEventTransferredAction,
-		RepositoryEventAnyAction,
-	} {
-		if _, ok := g.onRepositoryEvent[action]; ok {
-			for _, h := range g.onRepositoryEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event,
+		g.onRepositoryEvent[RepositoryEventTransferredAction],
+		g.onRepositoryEvent[RepositoryEventAnyAction],
+	)
 }
 
 // OnRepositoryEventPublicized registers callbacks listening to events of type github.RepositoryEvent and action 'publicized'.
@@ -725,33 +563,10 @@ func (g *EventHandler) handleRepositoryEventPublicized(ctx context.Context, deli
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		RepositoryEventPublicizedAction,
-		RepositoryEventAnyAction,
-	} {
-		if _, ok := g.onRepositoryEvent[action]; ok {
-			for _, h := range g.onRepositoryEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event,
+		g.onRepositoryEvent[RepositoryEventPublicizedAction],
+		g.onRepositoryEvent[RepositoryEventAnyAction],
+	)
 }
 
 // OnRepositoryEventPrivatized registers callbacks listening to events of type github.RepositoryEvent and action 'privatized'.
@@ -811,33 +626,10 @@ func (g *EventHandler) handleRepositoryEventPrivatized(ctx context.Context, deli
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		RepositoryEventPrivatizedAction,
-		RepositoryEventAnyAction,
-	} {
-		if _, ok := g.onRepositoryEvent[action]; ok {
-			for _, h := range g.onRepositoryEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event,
+		g.onRepositoryEvent[RepositoryEventPrivatizedAction],
+		g.onRepositoryEvent[RepositoryEventAnyAction],
+	)
 }
 
 // OnRepositoryEventAny registers callbacks listening to any events of type github.RepositoryEvent
@@ -890,29 +682,7 @@ func (g *EventHandler) handleRepositoryEventAny(ctx context.Context, deliveryID 
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onRepositoryEvent[RepositoryEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onRepositoryEvent[RepositoryEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event, g.onRepositoryEvent[RepositoryEventAnyAction])
 }
 
 // RepositoryEvent handles github.RepositoryEvent.

--- a/githubevents/events_repository_dispatch.go
+++ b/githubevents/events_repository_dispatch.go
@@ -42,7 +42,7 @@ type RepositoryDispatchEventHandleFunc func(ctx context.Context, deliveryID stri
 func (g *EventHandler) OnRepositoryDispatchEventAny(callbacks ...RepositoryDispatchEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryDispatchEvent == nil {
@@ -67,7 +67,7 @@ func (g *EventHandler) OnRepositoryDispatchEventAny(callbacks ...RepositoryDispa
 func (g *EventHandler) SetOnRepositoryDispatchEventAny(callbacks ...RepositoryDispatchEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryDispatchEvent == nil {

--- a/githubevents/events_repository_dispatch.go
+++ b/githubevents/events_repository_dispatch.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -80,29 +79,7 @@ func (g *EventHandler) handleRepositoryDispatchEventAny(ctx context.Context, del
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onRepositoryDispatchEvent[RepositoryDispatchEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onRepositoryDispatchEvent[RepositoryDispatchEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.RepositoryDispatchEvent](ctx, deliveryID, eventName, event, g.onRepositoryDispatchEvent[RepositoryDispatchEventAnyAction])
 }
 
 // RepositoryDispatchEvent handles github.RepositoryDispatchEvent.

--- a/githubevents/events_repository_ruleset.go
+++ b/githubevents/events_repository_ruleset.go
@@ -54,7 +54,7 @@ type RepositoryRulesetEventHandleFunc func(ctx context.Context, deliveryID strin
 func (g *EventHandler) OnRepositoryRulesetEventCreated(callbacks ...RepositoryRulesetEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryRulesetEvent == nil {
@@ -79,7 +79,7 @@ func (g *EventHandler) OnRepositoryRulesetEventCreated(callbacks ...RepositoryRu
 func (g *EventHandler) SetOnRepositoryRulesetEventCreated(callbacks ...RepositoryRulesetEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryRulesetEvent == nil {
@@ -140,7 +140,7 @@ func (g *EventHandler) handleRepositoryRulesetEventCreated(ctx context.Context, 
 func (g *EventHandler) OnRepositoryRulesetEventDeleted(callbacks ...RepositoryRulesetEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryRulesetEvent == nil {
@@ -165,7 +165,7 @@ func (g *EventHandler) OnRepositoryRulesetEventDeleted(callbacks ...RepositoryRu
 func (g *EventHandler) SetOnRepositoryRulesetEventDeleted(callbacks ...RepositoryRulesetEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryRulesetEvent == nil {
@@ -226,7 +226,7 @@ func (g *EventHandler) handleRepositoryRulesetEventDeleted(ctx context.Context, 
 func (g *EventHandler) OnRepositoryRulesetEventEdited(callbacks ...RepositoryRulesetEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryRulesetEvent == nil {
@@ -251,7 +251,7 @@ func (g *EventHandler) OnRepositoryRulesetEventEdited(callbacks ...RepositoryRul
 func (g *EventHandler) SetOnRepositoryRulesetEventEdited(callbacks ...RepositoryRulesetEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryRulesetEvent == nil {
@@ -312,7 +312,7 @@ func (g *EventHandler) handleRepositoryRulesetEventEdited(ctx context.Context, d
 func (g *EventHandler) OnRepositoryRulesetEventAny(callbacks ...RepositoryRulesetEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryRulesetEvent == nil {
@@ -337,7 +337,7 @@ func (g *EventHandler) OnRepositoryRulesetEventAny(callbacks ...RepositoryRulese
 func (g *EventHandler) SetOnRepositoryRulesetEventAny(callbacks ...RepositoryRulesetEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryRulesetEvent == nil {

--- a/githubevents/events_repository_ruleset.go
+++ b/githubevents/events_repository_ruleset.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -99,33 +98,10 @@ func (g *EventHandler) handleRepositoryRulesetEventCreated(ctx context.Context, 
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		RepositoryRulesetEventCreatedAction,
-		RepositoryRulesetEventAnyAction,
-	} {
-		if _, ok := g.onRepositoryRulesetEvent[action]; ok {
-			for _, h := range g.onRepositoryRulesetEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.RepositoryRulesetEvent](ctx, deliveryID, eventName, event,
+		g.onRepositoryRulesetEvent[RepositoryRulesetEventCreatedAction],
+		g.onRepositoryRulesetEvent[RepositoryRulesetEventAnyAction],
+	)
 }
 
 // OnRepositoryRulesetEventDeleted registers callbacks listening to events of type github.RepositoryRulesetEvent and action 'deleted'.
@@ -185,33 +161,10 @@ func (g *EventHandler) handleRepositoryRulesetEventDeleted(ctx context.Context, 
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		RepositoryRulesetEventDeletedAction,
-		RepositoryRulesetEventAnyAction,
-	} {
-		if _, ok := g.onRepositoryRulesetEvent[action]; ok {
-			for _, h := range g.onRepositoryRulesetEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.RepositoryRulesetEvent](ctx, deliveryID, eventName, event,
+		g.onRepositoryRulesetEvent[RepositoryRulesetEventDeletedAction],
+		g.onRepositoryRulesetEvent[RepositoryRulesetEventAnyAction],
+	)
 }
 
 // OnRepositoryRulesetEventEdited registers callbacks listening to events of type github.RepositoryRulesetEvent and action 'edited'.
@@ -271,33 +224,10 @@ func (g *EventHandler) handleRepositoryRulesetEventEdited(ctx context.Context, d
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		RepositoryRulesetEventEditedAction,
-		RepositoryRulesetEventAnyAction,
-	} {
-		if _, ok := g.onRepositoryRulesetEvent[action]; ok {
-			for _, h := range g.onRepositoryRulesetEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.RepositoryRulesetEvent](ctx, deliveryID, eventName, event,
+		g.onRepositoryRulesetEvent[RepositoryRulesetEventEditedAction],
+		g.onRepositoryRulesetEvent[RepositoryRulesetEventAnyAction],
+	)
 }
 
 // OnRepositoryRulesetEventAny registers callbacks listening to any events of type github.RepositoryRulesetEvent
@@ -350,29 +280,7 @@ func (g *EventHandler) handleRepositoryRulesetEventAny(ctx context.Context, deli
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onRepositoryRulesetEvent[RepositoryRulesetEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onRepositoryRulesetEvent[RepositoryRulesetEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.RepositoryRulesetEvent](ctx, deliveryID, eventName, event, g.onRepositoryRulesetEvent[RepositoryRulesetEventAnyAction])
 }
 
 // RepositoryRulesetEvent handles github.RepositoryRulesetEvent.

--- a/githubevents/events_repository_vulnerability_alert.go
+++ b/githubevents/events_repository_vulnerability_alert.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -99,33 +98,10 @@ func (g *EventHandler) handleRepositoryVulnerabilityAlertEventCreate(ctx context
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		RepositoryVulnerabilityAlertEventCreateAction,
-		RepositoryVulnerabilityAlertEventAnyAction,
-	} {
-		if _, ok := g.onRepositoryVulnerabilityAlertEvent[action]; ok {
-			for _, h := range g.onRepositoryVulnerabilityAlertEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.RepositoryVulnerabilityAlertEvent](ctx, deliveryID, eventName, event,
+		g.onRepositoryVulnerabilityAlertEvent[RepositoryVulnerabilityAlertEventCreateAction],
+		g.onRepositoryVulnerabilityAlertEvent[RepositoryVulnerabilityAlertEventAnyAction],
+	)
 }
 
 // OnRepositoryVulnerabilityAlertEventDismiss registers callbacks listening to events of type github.RepositoryVulnerabilityAlertEvent and action 'dismiss'.
@@ -185,33 +161,10 @@ func (g *EventHandler) handleRepositoryVulnerabilityAlertEventDismiss(ctx contex
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		RepositoryVulnerabilityAlertEventDismissAction,
-		RepositoryVulnerabilityAlertEventAnyAction,
-	} {
-		if _, ok := g.onRepositoryVulnerabilityAlertEvent[action]; ok {
-			for _, h := range g.onRepositoryVulnerabilityAlertEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.RepositoryVulnerabilityAlertEvent](ctx, deliveryID, eventName, event,
+		g.onRepositoryVulnerabilityAlertEvent[RepositoryVulnerabilityAlertEventDismissAction],
+		g.onRepositoryVulnerabilityAlertEvent[RepositoryVulnerabilityAlertEventAnyAction],
+	)
 }
 
 // OnRepositoryVulnerabilityAlertEventResolve registers callbacks listening to events of type github.RepositoryVulnerabilityAlertEvent and action 'resolve'.
@@ -271,33 +224,10 @@ func (g *EventHandler) handleRepositoryVulnerabilityAlertEventResolve(ctx contex
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		RepositoryVulnerabilityAlertEventResolveAction,
-		RepositoryVulnerabilityAlertEventAnyAction,
-	} {
-		if _, ok := g.onRepositoryVulnerabilityAlertEvent[action]; ok {
-			for _, h := range g.onRepositoryVulnerabilityAlertEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.RepositoryVulnerabilityAlertEvent](ctx, deliveryID, eventName, event,
+		g.onRepositoryVulnerabilityAlertEvent[RepositoryVulnerabilityAlertEventResolveAction],
+		g.onRepositoryVulnerabilityAlertEvent[RepositoryVulnerabilityAlertEventAnyAction],
+	)
 }
 
 // OnRepositoryVulnerabilityAlertEventAny registers callbacks listening to any events of type github.RepositoryVulnerabilityAlertEvent
@@ -350,29 +280,7 @@ func (g *EventHandler) handleRepositoryVulnerabilityAlertEventAny(ctx context.Co
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onRepositoryVulnerabilityAlertEvent[RepositoryVulnerabilityAlertEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onRepositoryVulnerabilityAlertEvent[RepositoryVulnerabilityAlertEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.RepositoryVulnerabilityAlertEvent](ctx, deliveryID, eventName, event, g.onRepositoryVulnerabilityAlertEvent[RepositoryVulnerabilityAlertEventAnyAction])
 }
 
 // RepositoryVulnerabilityAlertEvent handles github.RepositoryVulnerabilityAlertEvent.

--- a/githubevents/events_repository_vulnerability_alert.go
+++ b/githubevents/events_repository_vulnerability_alert.go
@@ -54,7 +54,7 @@ type RepositoryVulnerabilityAlertEventHandleFunc func(ctx context.Context, deliv
 func (g *EventHandler) OnRepositoryVulnerabilityAlertEventCreate(callbacks ...RepositoryVulnerabilityAlertEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryVulnerabilityAlertEvent == nil {
@@ -79,7 +79,7 @@ func (g *EventHandler) OnRepositoryVulnerabilityAlertEventCreate(callbacks ...Re
 func (g *EventHandler) SetOnRepositoryVulnerabilityAlertEventCreate(callbacks ...RepositoryVulnerabilityAlertEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryVulnerabilityAlertEvent == nil {
@@ -140,7 +140,7 @@ func (g *EventHandler) handleRepositoryVulnerabilityAlertEventCreate(ctx context
 func (g *EventHandler) OnRepositoryVulnerabilityAlertEventDismiss(callbacks ...RepositoryVulnerabilityAlertEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryVulnerabilityAlertEvent == nil {
@@ -165,7 +165,7 @@ func (g *EventHandler) OnRepositoryVulnerabilityAlertEventDismiss(callbacks ...R
 func (g *EventHandler) SetOnRepositoryVulnerabilityAlertEventDismiss(callbacks ...RepositoryVulnerabilityAlertEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryVulnerabilityAlertEvent == nil {
@@ -226,7 +226,7 @@ func (g *EventHandler) handleRepositoryVulnerabilityAlertEventDismiss(ctx contex
 func (g *EventHandler) OnRepositoryVulnerabilityAlertEventResolve(callbacks ...RepositoryVulnerabilityAlertEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryVulnerabilityAlertEvent == nil {
@@ -251,7 +251,7 @@ func (g *EventHandler) OnRepositoryVulnerabilityAlertEventResolve(callbacks ...R
 func (g *EventHandler) SetOnRepositoryVulnerabilityAlertEventResolve(callbacks ...RepositoryVulnerabilityAlertEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryVulnerabilityAlertEvent == nil {
@@ -312,7 +312,7 @@ func (g *EventHandler) handleRepositoryVulnerabilityAlertEventResolve(ctx contex
 func (g *EventHandler) OnRepositoryVulnerabilityAlertEventAny(callbacks ...RepositoryVulnerabilityAlertEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryVulnerabilityAlertEvent == nil {
@@ -337,7 +337,7 @@ func (g *EventHandler) OnRepositoryVulnerabilityAlertEventAny(callbacks ...Repos
 func (g *EventHandler) SetOnRepositoryVulnerabilityAlertEventAny(callbacks ...RepositoryVulnerabilityAlertEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onRepositoryVulnerabilityAlertEvent == nil {

--- a/githubevents/events_star.go
+++ b/githubevents/events_star.go
@@ -50,7 +50,7 @@ type StarEventHandleFunc func(ctx context.Context, deliveryID string, eventName 
 func (g *EventHandler) OnStarEventCreated(callbacks ...StarEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onStarEvent == nil {
@@ -75,7 +75,7 @@ func (g *EventHandler) OnStarEventCreated(callbacks ...StarEventHandleFunc) {
 func (g *EventHandler) SetOnStarEventCreated(callbacks ...StarEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onStarEvent == nil {
@@ -136,7 +136,7 @@ func (g *EventHandler) handleStarEventCreated(ctx context.Context, deliveryID st
 func (g *EventHandler) OnStarEventDeleted(callbacks ...StarEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onStarEvent == nil {
@@ -161,7 +161,7 @@ func (g *EventHandler) OnStarEventDeleted(callbacks ...StarEventHandleFunc) {
 func (g *EventHandler) SetOnStarEventDeleted(callbacks ...StarEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onStarEvent == nil {
@@ -222,7 +222,7 @@ func (g *EventHandler) handleStarEventDeleted(ctx context.Context, deliveryID st
 func (g *EventHandler) OnStarEventAny(callbacks ...StarEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onStarEvent == nil {
@@ -247,7 +247,7 @@ func (g *EventHandler) OnStarEventAny(callbacks ...StarEventHandleFunc) {
 func (g *EventHandler) SetOnStarEventAny(callbacks ...StarEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onStarEvent == nil {

--- a/githubevents/events_star.go
+++ b/githubevents/events_star.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -95,33 +94,10 @@ func (g *EventHandler) handleStarEventCreated(ctx context.Context, deliveryID st
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		StarEventCreatedAction,
-		StarEventAnyAction,
-	} {
-		if _, ok := g.onStarEvent[action]; ok {
-			for _, h := range g.onStarEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.StarEvent](ctx, deliveryID, eventName, event,
+		g.onStarEvent[StarEventCreatedAction],
+		g.onStarEvent[StarEventAnyAction],
+	)
 }
 
 // OnStarEventDeleted registers callbacks listening to events of type github.StarEvent and action 'deleted'.
@@ -181,33 +157,10 @@ func (g *EventHandler) handleStarEventDeleted(ctx context.Context, deliveryID st
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		StarEventDeletedAction,
-		StarEventAnyAction,
-	} {
-		if _, ok := g.onStarEvent[action]; ok {
-			for _, h := range g.onStarEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.StarEvent](ctx, deliveryID, eventName, event,
+		g.onStarEvent[StarEventDeletedAction],
+		g.onStarEvent[StarEventAnyAction],
+	)
 }
 
 // OnStarEventAny registers callbacks listening to any events of type github.StarEvent
@@ -260,29 +213,7 @@ func (g *EventHandler) handleStarEventAny(ctx context.Context, deliveryID string
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onStarEvent[StarEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onStarEvent[StarEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.StarEvent](ctx, deliveryID, eventName, event, g.onStarEvent[StarEventAnyAction])
 }
 
 // StarEvent handles github.StarEvent.

--- a/githubevents/events_status.go
+++ b/githubevents/events_status.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -80,29 +79,7 @@ func (g *EventHandler) handleStatusEventAny(ctx context.Context, deliveryID stri
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onStatusEvent[StatusEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onStatusEvent[StatusEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.StatusEvent](ctx, deliveryID, eventName, event, g.onStatusEvent[StatusEventAnyAction])
 }
 
 // StatusEvent handles github.StatusEvent.

--- a/githubevents/events_status.go
+++ b/githubevents/events_status.go
@@ -42,7 +42,7 @@ type StatusEventHandleFunc func(ctx context.Context, deliveryID string, eventNam
 func (g *EventHandler) OnStatusEventAny(callbacks ...StatusEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onStatusEvent == nil {
@@ -67,7 +67,7 @@ func (g *EventHandler) OnStatusEventAny(callbacks ...StatusEventHandleFunc) {
 func (g *EventHandler) SetOnStatusEventAny(callbacks ...StatusEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onStatusEvent == nil {

--- a/githubevents/events_team.go
+++ b/githubevents/events_team.go
@@ -62,7 +62,7 @@ type TeamEventHandleFunc func(ctx context.Context, deliveryID string, eventName 
 func (g *EventHandler) OnTeamEventCreated(callbacks ...TeamEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onTeamEvent == nil {
@@ -87,7 +87,7 @@ func (g *EventHandler) OnTeamEventCreated(callbacks ...TeamEventHandleFunc) {
 func (g *EventHandler) SetOnTeamEventCreated(callbacks ...TeamEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onTeamEvent == nil {
@@ -148,7 +148,7 @@ func (g *EventHandler) handleTeamEventCreated(ctx context.Context, deliveryID st
 func (g *EventHandler) OnTeamEventDeleted(callbacks ...TeamEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onTeamEvent == nil {
@@ -173,7 +173,7 @@ func (g *EventHandler) OnTeamEventDeleted(callbacks ...TeamEventHandleFunc) {
 func (g *EventHandler) SetOnTeamEventDeleted(callbacks ...TeamEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onTeamEvent == nil {
@@ -234,7 +234,7 @@ func (g *EventHandler) handleTeamEventDeleted(ctx context.Context, deliveryID st
 func (g *EventHandler) OnTeamEventEdited(callbacks ...TeamEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onTeamEvent == nil {
@@ -259,7 +259,7 @@ func (g *EventHandler) OnTeamEventEdited(callbacks ...TeamEventHandleFunc) {
 func (g *EventHandler) SetOnTeamEventEdited(callbacks ...TeamEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onTeamEvent == nil {
@@ -320,7 +320,7 @@ func (g *EventHandler) handleTeamEventEdited(ctx context.Context, deliveryID str
 func (g *EventHandler) OnTeamEventAddedToRepository(callbacks ...TeamEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onTeamEvent == nil {
@@ -345,7 +345,7 @@ func (g *EventHandler) OnTeamEventAddedToRepository(callbacks ...TeamEventHandle
 func (g *EventHandler) SetOnTeamEventAddedToRepository(callbacks ...TeamEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onTeamEvent == nil {
@@ -406,7 +406,7 @@ func (g *EventHandler) handleTeamEventAddedToRepository(ctx context.Context, del
 func (g *EventHandler) OnTeamEventRemovedFromRepository(callbacks ...TeamEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onTeamEvent == nil {
@@ -431,7 +431,7 @@ func (g *EventHandler) OnTeamEventRemovedFromRepository(callbacks ...TeamEventHa
 func (g *EventHandler) SetOnTeamEventRemovedFromRepository(callbacks ...TeamEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onTeamEvent == nil {
@@ -492,7 +492,7 @@ func (g *EventHandler) handleTeamEventRemovedFromRepository(ctx context.Context,
 func (g *EventHandler) OnTeamEventAny(callbacks ...TeamEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onTeamEvent == nil {
@@ -517,7 +517,7 @@ func (g *EventHandler) OnTeamEventAny(callbacks ...TeamEventHandleFunc) {
 func (g *EventHandler) SetOnTeamEventAny(callbacks ...TeamEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onTeamEvent == nil {

--- a/githubevents/events_team.go
+++ b/githubevents/events_team.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -107,33 +106,10 @@ func (g *EventHandler) handleTeamEventCreated(ctx context.Context, deliveryID st
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		TeamEventCreatedAction,
-		TeamEventAnyAction,
-	} {
-		if _, ok := g.onTeamEvent[action]; ok {
-			for _, h := range g.onTeamEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.TeamEvent](ctx, deliveryID, eventName, event,
+		g.onTeamEvent[TeamEventCreatedAction],
+		g.onTeamEvent[TeamEventAnyAction],
+	)
 }
 
 // OnTeamEventDeleted registers callbacks listening to events of type github.TeamEvent and action 'deleted'.
@@ -193,33 +169,10 @@ func (g *EventHandler) handleTeamEventDeleted(ctx context.Context, deliveryID st
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		TeamEventDeletedAction,
-		TeamEventAnyAction,
-	} {
-		if _, ok := g.onTeamEvent[action]; ok {
-			for _, h := range g.onTeamEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.TeamEvent](ctx, deliveryID, eventName, event,
+		g.onTeamEvent[TeamEventDeletedAction],
+		g.onTeamEvent[TeamEventAnyAction],
+	)
 }
 
 // OnTeamEventEdited registers callbacks listening to events of type github.TeamEvent and action 'edited'.
@@ -279,33 +232,10 @@ func (g *EventHandler) handleTeamEventEdited(ctx context.Context, deliveryID str
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		TeamEventEditedAction,
-		TeamEventAnyAction,
-	} {
-		if _, ok := g.onTeamEvent[action]; ok {
-			for _, h := range g.onTeamEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.TeamEvent](ctx, deliveryID, eventName, event,
+		g.onTeamEvent[TeamEventEditedAction],
+		g.onTeamEvent[TeamEventAnyAction],
+	)
 }
 
 // OnTeamEventAddedToRepository registers callbacks listening to events of type github.TeamEvent and action 'added_to_repository'.
@@ -365,33 +295,10 @@ func (g *EventHandler) handleTeamEventAddedToRepository(ctx context.Context, del
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		TeamEventAddedToRepositoryAction,
-		TeamEventAnyAction,
-	} {
-		if _, ok := g.onTeamEvent[action]; ok {
-			for _, h := range g.onTeamEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.TeamEvent](ctx, deliveryID, eventName, event,
+		g.onTeamEvent[TeamEventAddedToRepositoryAction],
+		g.onTeamEvent[TeamEventAnyAction],
+	)
 }
 
 // OnTeamEventRemovedFromRepository registers callbacks listening to events of type github.TeamEvent and action 'removed_from_repository'.
@@ -451,33 +358,10 @@ func (g *EventHandler) handleTeamEventRemovedFromRepository(ctx context.Context,
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		TeamEventRemovedFromRepositoryAction,
-		TeamEventAnyAction,
-	} {
-		if _, ok := g.onTeamEvent[action]; ok {
-			for _, h := range g.onTeamEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.TeamEvent](ctx, deliveryID, eventName, event,
+		g.onTeamEvent[TeamEventRemovedFromRepositoryAction],
+		g.onTeamEvent[TeamEventAnyAction],
+	)
 }
 
 // OnTeamEventAny registers callbacks listening to any events of type github.TeamEvent
@@ -530,29 +414,7 @@ func (g *EventHandler) handleTeamEventAny(ctx context.Context, deliveryID string
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onTeamEvent[TeamEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onTeamEvent[TeamEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.TeamEvent](ctx, deliveryID, eventName, event, g.onTeamEvent[TeamEventAnyAction])
 }
 
 // TeamEvent handles github.TeamEvent.

--- a/githubevents/events_team_add.go
+++ b/githubevents/events_team_add.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -80,29 +79,7 @@ func (g *EventHandler) handleTeamAddEventAny(ctx context.Context, deliveryID str
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onTeamAddEvent[TeamAddEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onTeamAddEvent[TeamAddEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.TeamAddEvent](ctx, deliveryID, eventName, event, g.onTeamAddEvent[TeamAddEventAnyAction])
 }
 
 // TeamAddEvent handles github.TeamAddEvent.

--- a/githubevents/events_team_add.go
+++ b/githubevents/events_team_add.go
@@ -42,7 +42,7 @@ type TeamAddEventHandleFunc func(ctx context.Context, deliveryID string, eventNa
 func (g *EventHandler) OnTeamAddEventAny(callbacks ...TeamAddEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onTeamAddEvent == nil {
@@ -67,7 +67,7 @@ func (g *EventHandler) OnTeamAddEventAny(callbacks ...TeamAddEventHandleFunc) {
 func (g *EventHandler) SetOnTeamAddEventAny(callbacks ...TeamAddEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onTeamAddEvent == nil {

--- a/githubevents/events_watch.go
+++ b/githubevents/events_watch.go
@@ -42,7 +42,7 @@ type WatchEventHandleFunc func(ctx context.Context, deliveryID string, eventName
 func (g *EventHandler) OnWatchEventAny(callbacks ...WatchEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onWatchEvent == nil {
@@ -67,7 +67,7 @@ func (g *EventHandler) OnWatchEventAny(callbacks ...WatchEventHandleFunc) {
 func (g *EventHandler) SetOnWatchEventAny(callbacks ...WatchEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onWatchEvent == nil {

--- a/githubevents/events_watch.go
+++ b/githubevents/events_watch.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -80,29 +79,7 @@ func (g *EventHandler) handleWatchEventAny(ctx context.Context, deliveryID strin
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onWatchEvent[WatchEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onWatchEvent[WatchEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.WatchEvent](ctx, deliveryID, eventName, event, g.onWatchEvent[WatchEventAnyAction])
 }
 
 // WatchEvent handles github.WatchEvent.

--- a/githubevents/events_workflow_dispatch.go
+++ b/githubevents/events_workflow_dispatch.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -80,29 +79,7 @@ func (g *EventHandler) handleWorkflowDispatchEventAny(ctx context.Context, deliv
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onWorkflowDispatchEvent[WorkflowDispatchEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onWorkflowDispatchEvent[WorkflowDispatchEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.WorkflowDispatchEvent](ctx, deliveryID, eventName, event, g.onWorkflowDispatchEvent[WorkflowDispatchEventAnyAction])
 }
 
 // WorkflowDispatchEvent handles github.WorkflowDispatchEvent.

--- a/githubevents/events_workflow_dispatch.go
+++ b/githubevents/events_workflow_dispatch.go
@@ -42,7 +42,7 @@ type WorkflowDispatchEventHandleFunc func(ctx context.Context, deliveryID string
 func (g *EventHandler) OnWorkflowDispatchEventAny(callbacks ...WorkflowDispatchEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onWorkflowDispatchEvent == nil {
@@ -67,7 +67,7 @@ func (g *EventHandler) OnWorkflowDispatchEventAny(callbacks ...WorkflowDispatchE
 func (g *EventHandler) SetOnWorkflowDispatchEventAny(callbacks ...WorkflowDispatchEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onWorkflowDispatchEvent == nil {

--- a/githubevents/events_workflow_job.go
+++ b/githubevents/events_workflow_job.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -99,33 +98,10 @@ func (g *EventHandler) handleWorkflowJobEventQueued(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		WorkflowJobEventQueuedAction,
-		WorkflowJobEventAnyAction,
-	} {
-		if _, ok := g.onWorkflowJobEvent[action]; ok {
-			for _, h := range g.onWorkflowJobEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.WorkflowJobEvent](ctx, deliveryID, eventName, event,
+		g.onWorkflowJobEvent[WorkflowJobEventQueuedAction],
+		g.onWorkflowJobEvent[WorkflowJobEventAnyAction],
+	)
 }
 
 // OnWorkflowJobEventInProgress registers callbacks listening to events of type github.WorkflowJobEvent and action 'in_progress'.
@@ -185,33 +161,10 @@ func (g *EventHandler) handleWorkflowJobEventInProgress(ctx context.Context, del
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		WorkflowJobEventInProgressAction,
-		WorkflowJobEventAnyAction,
-	} {
-		if _, ok := g.onWorkflowJobEvent[action]; ok {
-			for _, h := range g.onWorkflowJobEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.WorkflowJobEvent](ctx, deliveryID, eventName, event,
+		g.onWorkflowJobEvent[WorkflowJobEventInProgressAction],
+		g.onWorkflowJobEvent[WorkflowJobEventAnyAction],
+	)
 }
 
 // OnWorkflowJobEventCompleted registers callbacks listening to events of type github.WorkflowJobEvent and action 'completed'.
@@ -271,33 +224,10 @@ func (g *EventHandler) handleWorkflowJobEventCompleted(ctx context.Context, deli
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		WorkflowJobEventCompletedAction,
-		WorkflowJobEventAnyAction,
-	} {
-		if _, ok := g.onWorkflowJobEvent[action]; ok {
-			for _, h := range g.onWorkflowJobEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.WorkflowJobEvent](ctx, deliveryID, eventName, event,
+		g.onWorkflowJobEvent[WorkflowJobEventCompletedAction],
+		g.onWorkflowJobEvent[WorkflowJobEventAnyAction],
+	)
 }
 
 // OnWorkflowJobEventAny registers callbacks listening to any events of type github.WorkflowJobEvent
@@ -350,29 +280,7 @@ func (g *EventHandler) handleWorkflowJobEventAny(ctx context.Context, deliveryID
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onWorkflowJobEvent[WorkflowJobEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onWorkflowJobEvent[WorkflowJobEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.WorkflowJobEvent](ctx, deliveryID, eventName, event, g.onWorkflowJobEvent[WorkflowJobEventAnyAction])
 }
 
 // WorkflowJobEvent handles github.WorkflowJobEvent.

--- a/githubevents/events_workflow_job.go
+++ b/githubevents/events_workflow_job.go
@@ -54,7 +54,7 @@ type WorkflowJobEventHandleFunc func(ctx context.Context, deliveryID string, eve
 func (g *EventHandler) OnWorkflowJobEventQueued(callbacks ...WorkflowJobEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onWorkflowJobEvent == nil {
@@ -79,7 +79,7 @@ func (g *EventHandler) OnWorkflowJobEventQueued(callbacks ...WorkflowJobEventHan
 func (g *EventHandler) SetOnWorkflowJobEventQueued(callbacks ...WorkflowJobEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onWorkflowJobEvent == nil {
@@ -140,7 +140,7 @@ func (g *EventHandler) handleWorkflowJobEventQueued(ctx context.Context, deliver
 func (g *EventHandler) OnWorkflowJobEventInProgress(callbacks ...WorkflowJobEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onWorkflowJobEvent == nil {
@@ -165,7 +165,7 @@ func (g *EventHandler) OnWorkflowJobEventInProgress(callbacks ...WorkflowJobEven
 func (g *EventHandler) SetOnWorkflowJobEventInProgress(callbacks ...WorkflowJobEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onWorkflowJobEvent == nil {
@@ -226,7 +226,7 @@ func (g *EventHandler) handleWorkflowJobEventInProgress(ctx context.Context, del
 func (g *EventHandler) OnWorkflowJobEventCompleted(callbacks ...WorkflowJobEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onWorkflowJobEvent == nil {
@@ -251,7 +251,7 @@ func (g *EventHandler) OnWorkflowJobEventCompleted(callbacks ...WorkflowJobEvent
 func (g *EventHandler) SetOnWorkflowJobEventCompleted(callbacks ...WorkflowJobEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onWorkflowJobEvent == nil {
@@ -312,7 +312,7 @@ func (g *EventHandler) handleWorkflowJobEventCompleted(ctx context.Context, deli
 func (g *EventHandler) OnWorkflowJobEventAny(callbacks ...WorkflowJobEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onWorkflowJobEvent == nil {
@@ -337,7 +337,7 @@ func (g *EventHandler) OnWorkflowJobEventAny(callbacks ...WorkflowJobEventHandle
 func (g *EventHandler) SetOnWorkflowJobEventAny(callbacks ...WorkflowJobEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onWorkflowJobEvent == nil {

--- a/githubevents/events_workflow_run.go
+++ b/githubevents/events_workflow_run.go
@@ -50,7 +50,7 @@ type WorkflowRunEventHandleFunc func(ctx context.Context, deliveryID string, eve
 func (g *EventHandler) OnWorkflowRunEventRequested(callbacks ...WorkflowRunEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onWorkflowRunEvent == nil {
@@ -75,7 +75,7 @@ func (g *EventHandler) OnWorkflowRunEventRequested(callbacks ...WorkflowRunEvent
 func (g *EventHandler) SetOnWorkflowRunEventRequested(callbacks ...WorkflowRunEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onWorkflowRunEvent == nil {
@@ -136,7 +136,7 @@ func (g *EventHandler) handleWorkflowRunEventRequested(ctx context.Context, deli
 func (g *EventHandler) OnWorkflowRunEventCompleted(callbacks ...WorkflowRunEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onWorkflowRunEvent == nil {
@@ -161,7 +161,7 @@ func (g *EventHandler) OnWorkflowRunEventCompleted(callbacks ...WorkflowRunEvent
 func (g *EventHandler) SetOnWorkflowRunEventCompleted(callbacks ...WorkflowRunEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onWorkflowRunEvent == nil {
@@ -222,7 +222,7 @@ func (g *EventHandler) handleWorkflowRunEventCompleted(ctx context.Context, deli
 func (g *EventHandler) OnWorkflowRunEventAny(callbacks ...WorkflowRunEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onWorkflowRunEvent == nil {
@@ -247,7 +247,7 @@ func (g *EventHandler) OnWorkflowRunEventAny(callbacks ...WorkflowRunEventHandle
 func (g *EventHandler) SetOnWorkflowRunEventAny(callbacks ...WorkflowRunEventHandleFunc) {
 	g.mu.Lock()
 	defer g.mu.Unlock()
-	if callbacks == nil || len(callbacks) == 0 {
+	if len(callbacks) == 0 {
 		panic("callbacks is nil or empty")
 	}
 	if g.onWorkflowRunEvent == nil {

--- a/githubevents/events_workflow_run.go
+++ b/githubevents/events_workflow_run.go
@@ -11,7 +11,6 @@ import (
 	"context"
 	"fmt"
 	"github.com/google/go-github/v89/github"
-	"golang.org/x/sync/errgroup"
 )
 
 // Actions are used to identify registered callbacks.
@@ -95,33 +94,10 @@ func (g *EventHandler) handleWorkflowRunEventRequested(ctx context.Context, deli
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		WorkflowRunEventRequestedAction,
-		WorkflowRunEventAnyAction,
-	} {
-		if _, ok := g.onWorkflowRunEvent[action]; ok {
-			for _, h := range g.onWorkflowRunEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.WorkflowRunEvent](ctx, deliveryID, eventName, event,
+		g.onWorkflowRunEvent[WorkflowRunEventRequestedAction],
+		g.onWorkflowRunEvent[WorkflowRunEventAnyAction],
+	)
 }
 
 // OnWorkflowRunEventCompleted registers callbacks listening to events of type github.WorkflowRunEvent and action 'completed'.
@@ -181,33 +157,10 @@ func (g *EventHandler) handleWorkflowRunEventCompleted(ctx context.Context, deli
 			*event.Action,
 		)
 	}
-	eg := new(errgroup.Group)
-	for _, action := range []string{
-		WorkflowRunEventCompletedAction,
-		WorkflowRunEventAnyAction,
-	} {
-		if _, ok := g.onWorkflowRunEvent[action]; ok {
-			for _, h := range g.onWorkflowRunEvent[action] {
-				handle := h
-				eg.Go(func() (err error) {
-					defer func() {
-						if r := recover(); r != nil {
-							err = fmt.Errorf("recovered from panic: %v", r)
-						}
-					}()
-					err = handle(ctx, deliveryID, eventName, event)
-					if err != nil {
-						return err
-					}
-					return nil
-				})
-			}
-		}
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.WorkflowRunEvent](ctx, deliveryID, eventName, event,
+		g.onWorkflowRunEvent[WorkflowRunEventCompletedAction],
+		g.onWorkflowRunEvent[WorkflowRunEventAnyAction],
+	)
 }
 
 // OnWorkflowRunEventAny registers callbacks listening to any events of type github.WorkflowRunEvent
@@ -260,29 +213,7 @@ func (g *EventHandler) handleWorkflowRunEventAny(ctx context.Context, deliveryID
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onWorkflowRunEvent[WorkflowRunEventAnyAction]; !ok {
-		return nil
-	}
-	eg := new(errgroup.Group)
-	for _, h := range g.onWorkflowRunEvent[WorkflowRunEventAnyAction] {
-		handle := h
-		eg.Go(func() (err error) {
-			defer func() {
-				if r := recover(); r != nil {
-					err = fmt.Errorf("recovered from panic: %v", r)
-				}
-			}()
-			err = handle(ctx, deliveryID, eventName, event)
-			if err != nil {
-				return err
-			}
-			return nil
-		})
-	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return dispatch[*github.WorkflowRunEvent](ctx, deliveryID, eventName, event, g.onWorkflowRunEvent[WorkflowRunEventAnyAction])
 }
 
 // WorkflowRunEvent handles github.WorkflowRunEvent.


### PR DESCRIPTION
## What

Collapse the ~500 copy-pasted concurrency loops into one hand-written generic helper.

- new `githubevents/dispatch.go` with `dispatch[T]`, the single implementation of the errgroup + panic-recovery + first-error-wins loop
- generated `handle*` methods now call `dispatch(...)` instead of repeating ~27 lines each
- characterization tests (`githubevents/dispatch_test.go`) lock the behavior through the public API before the refactor

Net: **+722 / -5579 lines**. Stacked on #280.

## Why

The same errgroup/recover block was generated hundreds of times. One generic helper is far easier to reason about and test, and it only touches unexported internals so the public API is unchanged.

Behavior is preserved *exactly*, and i was deliberate about it: same errgroup first-error-wins semantics (not `errors.Join`, so if two callbacks fail only the first surfaces, like before), the exact `"recovered from panic: %v"` message, and all the guard / wrong-action errors verbatim. The characterization tests (panic recovery, fan-out count, error propagation, empty-action rejection, the Any path) were written to pass on the old code first, then kept passing after the refactor.

## Testing

- `go test ./githubevents/ -run TestDispatch -v` -> 5/5, unchanged before and after the refactor
- `make test` green (incl. the 100+ generated per-event test files), `make apidiff` -> API compatible
- `grep -rl errgroup githubevents/` -> only `dispatch.go` + `events.go` (the bespoke `handleError`), no `events_*.go`

## Checklist
- [x] Tests added/updated (`dispatch_test.go` characterization suite)
- [x] No breaking changes (unexported internals only, apidiff compatible)
- [x] Readable commit history (tests first, then the helper)
- [ ] AI code review considered and comments resolved
