### PR TITLE
ci(renovate): auto-bump go-github in examples and readme

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,5 +2,23 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
         "github>cbrgm/cbrgm//renovate/preset"
+    ],
+    "postUpdateOptions": [
+        "gomodUpdateImportPaths"
+    ],
+    "customManagers": [
+        {
+            "customType": "regex",
+            "fileMatch": [
+                "^README\\.md$"
+            ],
+            "matchStrings": [
+                "github\\.com/google/go-github/(?<currentValue>v\\d+)/github"
+            ],
+            "depNameTemplate": "google/go-github",
+            "datasourceTemplate": "github-tags",
+            "versioningTemplate": "regex:^v(?<major>\\d+)(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))?$",
+            "autoReplaceStringTemplate": "github.com/google/go-github/v{{{newMajor}}}/github"
+        }
     ]
 }


### PR DESCRIPTION
## What

Make Renovate bump the go-github version *everywhere*, not just the top-level `go.mod`.

- `postUpdateOptions: ["gomodUpdateImportPaths"]` -> on a major bump, Renovate rewrites the Go import paths (`.../v89/github` -> `.../v90/github`) in every module: the `examples/*` modules, the hand-written `githubevents/dispatch_test.go`, and the generated files.
- a `customManagers` regex that keeps the README's import snippet in sync, tracked against go-github's github tags.

## Why

Right now a go-github major bump only edits `go.mod`. The import paths in `examples/*/*.go` and the README code block still point at the old major, so they get bumped by hand every time. `gomodUpdateImportPaths` is the built-in Renovate feature for exactly this (it runs the `mod` tool per module), so all the `.go` files move automatically. The README isn't a Go file, so it needs the small regex manager.

Note on the examples: they depend on a *published* `githubevents/v2` (no local `replace`), so they can only move to a new go-github major once a githubevents release using that major exists. After that release, Renovate bumps the githubevents dep and go-github together, and this config rewrites the import paths for you.

## Testing

```
$ renovate-config-validator .github/renovate.json
 INFO: Config validated successfully
```

The README manager validates against the schema. Since go's semantic-import-versioning (major-in-path) is a bit awkward for a non-code file, i'd confirm it on the next Renovate dry-run / first real bump, it's doc-only so nothing breaks if it needs a tweak.

## Checklist
- [x] Tests added/updated (config validated; behavior is Renovate-side)
- [x] No breaking changes (CI/tooling config only)
- [x] Readable commit history (1 commit)
- [x] AI code review considered and comments resolved
