### PR TITLE
fix(githubevents): runtime hardening (data race, error wrapping, go floor)

### DIFF
--- a/.github/workflows/go.yaml
+++ b/.github/workflows/go.yaml
@@ -40,5 +40,8 @@ jobs:
       - name: run tests
         run: make test
 
+      - name: run tests (race)
+        run: make test-race
+
       - name: apidiff
         run: make apidiff

--- a/Makefile
+++ b/Makefile
@@ -29,6 +29,10 @@ format:
 test:
 	@for PKG in $(PACKAGES); do $(GO) test -cover $$PKG || exit 1; done;
 
+.PHONY: test-race
+test-race:
+	CGO_ENABLED=1 go test -race ./...
+
 .PHONY: generate
 generate: build
 	./bin/githubhook-gen --output=githubevents

--- a/gen/template_webhook_event.go.tmpl
+++ b/gen/template_webhook_event.go.tmpl
@@ -93,7 +93,10 @@ func (g *EventHandler) handleBeforeAny(ctx context.Context, deliveryID string, e
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[any](ctx, deliveryID, eventName, event, g.onBeforeAny[EventAnyAction])
+	g.mu.RLock()
+	handlers := g.onBeforeAny[EventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[any](ctx, deliveryID, eventName, event, handlers)
 }
 
 // OnAfterAny registers callbacks which are triggered after any event.
@@ -135,7 +138,10 @@ func (g *EventHandler) handleAfterAny(ctx context.Context, deliveryID string, ev
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[any](ctx, deliveryID, eventName, event, g.onAfterAny[EventAnyAction])
+	g.mu.RLock()
+	handlers := g.onAfterAny[EventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[any](ctx, deliveryID, eventName, event, handlers)
 }
 
 // ErrorEventHandleFunc represents a generic callback function which receives any event and an error thrown by
@@ -181,29 +187,24 @@ func (g *EventHandler) handleError(ctx context.Context, deliveryID string, event
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onErrorAny[EventAnyAction]; !ok {
+	g.mu.RLock()
+	handlers := g.onErrorAny[EventAnyAction]
+	g.mu.RUnlock()
+	if len(handlers) == 0 {
 		return srcErr
 	}
 	eg := new(errgroup.Group)
-	for _, h := range g.onErrorAny[EventAnyAction] {
-		handle := h
+	for _, h := range handlers {
 		eg.Go(func() (err error) {
 			defer func() {
 				if r := recover(); r != nil {
 					err = fmt.Errorf("recovered from panic: %v", r)
 				}
 			}()
-			err = handle(ctx, deliveryID, eventName, event, srcErr)
-			if err != nil {
-				return err
-			}
-			return nil
+			return h(ctx, deliveryID, eventName, event, srcErr)
 		})
 	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return eg.Wait()
 }
 
 // HandleEventRequest parses a Github event from http.Request and executes registered handlers.

--- a/gen/template_webhook_event.go.tmpl
+++ b/gen/template_webhook_event.go.tmpl
@@ -211,11 +211,11 @@ func (g *EventHandler) handleError(ctx context.Context, deliveryID string, event
 func (g *EventHandler) HandleEventRequest(req *http.Request) error {
 	payload, err := github.ValidatePayload(req, []byte(g.WebhookSecret))
 	if err != nil {
-		return fmt.Errorf("could not validate webhook payload: err=%s\n", err)
+		return fmt.Errorf("could not validate webhook payload: %w", err)
 	}
 	event, err := github.ParseWebHook(github.WebHookType(req), payload)
 	if err != nil {
-		return fmt.Errorf("could not parse webhook: err=%s\n", err)
+		return fmt.Errorf("could not parse webhook: %w", err)
 	}
 
 	deliveryID := github.DeliveryID(req)

--- a/gen/template_webhook_event_types.go.tmpl
+++ b/gen/template_webhook_event_types.go.tmpl
@@ -95,10 +95,11 @@ func (g *EventHandler) handle{{ $action.Handler }}(ctx context.Context, delivery
 			*event.Action,
 		)
 	}
-	return dispatch[*github.{{ $webhook.Event }}](ctx, deliveryID, eventName, event,
-		g.on{{ $webhook.Event }}[{{ $action.Handler }}Action],
-		g.on{{ $webhook.Event }}[{{ $webhook.Event }}AnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.on{{ $webhook.Event }}[{{ $action.Handler }}Action]
+	anyHandlers := g.on{{ $webhook.Event }}[{{ $webhook.Event }}AnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.{{ $webhook.Event }}](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 {{ end }}
@@ -153,7 +154,10 @@ func (g *EventHandler) handle{{ $webhook.Event }}Any(ctx context.Context, delive
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.{{ $webhook.Event }}](ctx, deliveryID, eventName, event, g.on{{ $webhook.Event }}[{{ $webhook.Event }}AnyAction])
+	g.mu.RLock()
+	anyHandlers := g.on{{ $webhook.Event }}[{{ $webhook.Event }}AnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.{{ $webhook.Event }}](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // {{ $webhook.Event }} handles github.{{ $webhook.Event }}.

--- a/githubevents/events.go
+++ b/githubevents/events.go
@@ -261,11 +261,11 @@ func (g *EventHandler) handleError(ctx context.Context, deliveryID string, event
 func (g *EventHandler) HandleEventRequest(req *http.Request) error {
 	payload, err := github.ValidatePayload(req, []byte(g.WebhookSecret))
 	if err != nil {
-		return fmt.Errorf("could not validate webhook payload: err=%s\n", err)
+		return fmt.Errorf("could not validate webhook payload: %w", err)
 	}
 	event, err := github.ParseWebHook(github.WebHookType(req), payload)
 	if err != nil {
-		return fmt.Errorf("could not parse webhook: err=%s\n", err)
+		return fmt.Errorf("could not parse webhook: %w", err)
 	}
 
 	deliveryID := github.DeliveryID(req)

--- a/githubevents/events.go
+++ b/githubevents/events.go
@@ -143,7 +143,10 @@ func (g *EventHandler) handleBeforeAny(ctx context.Context, deliveryID string, e
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[any](ctx, deliveryID, eventName, event, g.onBeforeAny[EventAnyAction])
+	g.mu.RLock()
+	handlers := g.onBeforeAny[EventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[any](ctx, deliveryID, eventName, event, handlers)
 }
 
 // OnAfterAny registers callbacks which are triggered after any event.
@@ -185,7 +188,10 @@ func (g *EventHandler) handleAfterAny(ctx context.Context, deliveryID string, ev
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[any](ctx, deliveryID, eventName, event, g.onAfterAny[EventAnyAction])
+	g.mu.RLock()
+	handlers := g.onAfterAny[EventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[any](ctx, deliveryID, eventName, event, handlers)
 }
 
 // ErrorEventHandleFunc represents a generic callback function which receives any event and an error thrown by
@@ -231,29 +237,24 @@ func (g *EventHandler) handleError(ctx context.Context, deliveryID string, event
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	if _, ok := g.onErrorAny[EventAnyAction]; !ok {
+	g.mu.RLock()
+	handlers := g.onErrorAny[EventAnyAction]
+	g.mu.RUnlock()
+	if len(handlers) == 0 {
 		return srcErr
 	}
 	eg := new(errgroup.Group)
-	for _, h := range g.onErrorAny[EventAnyAction] {
-		handle := h
+	for _, h := range handlers {
 		eg.Go(func() (err error) {
 			defer func() {
 				if r := recover(); r != nil {
 					err = fmt.Errorf("recovered from panic: %v", r)
 				}
 			}()
-			err = handle(ctx, deliveryID, eventName, event, srcErr)
-			if err != nil {
-				return err
-			}
-			return nil
+			return h(ctx, deliveryID, eventName, event, srcErr)
 		})
 	}
-	if err := eg.Wait(); err != nil {
-		return err
-	}
-	return nil
+	return eg.Wait()
 }
 
 // HandleEventRequest parses a Github event from http.Request and executes registered handlers.

--- a/githubevents/events_branch_protection_rule.go
+++ b/githubevents/events_branch_protection_rule.go
@@ -98,10 +98,11 @@ func (g *EventHandler) handleBranchProtectionRuleEventCreated(ctx context.Contex
 			*event.Action,
 		)
 	}
-	return dispatch[*github.BranchProtectionRuleEvent](ctx, deliveryID, eventName, event,
-		g.onBranchProtectionRuleEvent[BranchProtectionRuleEventCreatedAction],
-		g.onBranchProtectionRuleEvent[BranchProtectionRuleEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onBranchProtectionRuleEvent[BranchProtectionRuleEventCreatedAction]
+	anyHandlers := g.onBranchProtectionRuleEvent[BranchProtectionRuleEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.BranchProtectionRuleEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnBranchProtectionRuleEventEdited registers callbacks listening to events of type github.BranchProtectionRuleEvent and action 'edited'.
@@ -161,10 +162,11 @@ func (g *EventHandler) handleBranchProtectionRuleEventEdited(ctx context.Context
 			*event.Action,
 		)
 	}
-	return dispatch[*github.BranchProtectionRuleEvent](ctx, deliveryID, eventName, event,
-		g.onBranchProtectionRuleEvent[BranchProtectionRuleEventEditedAction],
-		g.onBranchProtectionRuleEvent[BranchProtectionRuleEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onBranchProtectionRuleEvent[BranchProtectionRuleEventEditedAction]
+	anyHandlers := g.onBranchProtectionRuleEvent[BranchProtectionRuleEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.BranchProtectionRuleEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnBranchProtectionRuleEventDeleted registers callbacks listening to events of type github.BranchProtectionRuleEvent and action 'deleted'.
@@ -224,10 +226,11 @@ func (g *EventHandler) handleBranchProtectionRuleEventDeleted(ctx context.Contex
 			*event.Action,
 		)
 	}
-	return dispatch[*github.BranchProtectionRuleEvent](ctx, deliveryID, eventName, event,
-		g.onBranchProtectionRuleEvent[BranchProtectionRuleEventDeletedAction],
-		g.onBranchProtectionRuleEvent[BranchProtectionRuleEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onBranchProtectionRuleEvent[BranchProtectionRuleEventDeletedAction]
+	anyHandlers := g.onBranchProtectionRuleEvent[BranchProtectionRuleEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.BranchProtectionRuleEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnBranchProtectionRuleEventAny registers callbacks listening to any events of type github.BranchProtectionRuleEvent
@@ -280,7 +283,10 @@ func (g *EventHandler) handleBranchProtectionRuleEventAny(ctx context.Context, d
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.BranchProtectionRuleEvent](ctx, deliveryID, eventName, event, g.onBranchProtectionRuleEvent[BranchProtectionRuleEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onBranchProtectionRuleEvent[BranchProtectionRuleEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.BranchProtectionRuleEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // BranchProtectionRuleEvent handles github.BranchProtectionRuleEvent.

--- a/githubevents/events_check_run.go
+++ b/githubevents/events_check_run.go
@@ -102,10 +102,11 @@ func (g *EventHandler) handleCheckRunEventCreated(ctx context.Context, deliveryI
 			*event.Action,
 		)
 	}
-	return dispatch[*github.CheckRunEvent](ctx, deliveryID, eventName, event,
-		g.onCheckRunEvent[CheckRunEventCreatedAction],
-		g.onCheckRunEvent[CheckRunEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onCheckRunEvent[CheckRunEventCreatedAction]
+	anyHandlers := g.onCheckRunEvent[CheckRunEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.CheckRunEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnCheckRunEventCompleted registers callbacks listening to events of type github.CheckRunEvent and action 'completed'.
@@ -165,10 +166,11 @@ func (g *EventHandler) handleCheckRunEventCompleted(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	return dispatch[*github.CheckRunEvent](ctx, deliveryID, eventName, event,
-		g.onCheckRunEvent[CheckRunEventCompletedAction],
-		g.onCheckRunEvent[CheckRunEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onCheckRunEvent[CheckRunEventCompletedAction]
+	anyHandlers := g.onCheckRunEvent[CheckRunEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.CheckRunEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnCheckRunEventReRequested registers callbacks listening to events of type github.CheckRunEvent and action 'rerequested'.
@@ -228,10 +230,11 @@ func (g *EventHandler) handleCheckRunEventReRequested(ctx context.Context, deliv
 			*event.Action,
 		)
 	}
-	return dispatch[*github.CheckRunEvent](ctx, deliveryID, eventName, event,
-		g.onCheckRunEvent[CheckRunEventReRequestedAction],
-		g.onCheckRunEvent[CheckRunEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onCheckRunEvent[CheckRunEventReRequestedAction]
+	anyHandlers := g.onCheckRunEvent[CheckRunEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.CheckRunEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnCheckRunEventRequestAction registers callbacks listening to events of type github.CheckRunEvent and action 'requested_action'.
@@ -291,10 +294,11 @@ func (g *EventHandler) handleCheckRunEventRequestAction(ctx context.Context, del
 			*event.Action,
 		)
 	}
-	return dispatch[*github.CheckRunEvent](ctx, deliveryID, eventName, event,
-		g.onCheckRunEvent[CheckRunEventRequestActionAction],
-		g.onCheckRunEvent[CheckRunEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onCheckRunEvent[CheckRunEventRequestActionAction]
+	anyHandlers := g.onCheckRunEvent[CheckRunEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.CheckRunEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnCheckRunEventAny registers callbacks listening to any events of type github.CheckRunEvent
@@ -347,7 +351,10 @@ func (g *EventHandler) handleCheckRunEventAny(ctx context.Context, deliveryID st
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.CheckRunEvent](ctx, deliveryID, eventName, event, g.onCheckRunEvent[CheckRunEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onCheckRunEvent[CheckRunEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.CheckRunEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // CheckRunEvent handles github.CheckRunEvent.

--- a/githubevents/events_check_suite.go
+++ b/githubevents/events_check_suite.go
@@ -98,10 +98,11 @@ func (g *EventHandler) handleCheckSuiteEventCompleted(ctx context.Context, deliv
 			*event.Action,
 		)
 	}
-	return dispatch[*github.CheckSuiteEvent](ctx, deliveryID, eventName, event,
-		g.onCheckSuiteEvent[CheckSuiteEventCompletedAction],
-		g.onCheckSuiteEvent[CheckSuiteEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onCheckSuiteEvent[CheckSuiteEventCompletedAction]
+	anyHandlers := g.onCheckSuiteEvent[CheckSuiteEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.CheckSuiteEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnCheckSuiteEventRequested registers callbacks listening to events of type github.CheckSuiteEvent and action 'requested'.
@@ -161,10 +162,11 @@ func (g *EventHandler) handleCheckSuiteEventRequested(ctx context.Context, deliv
 			*event.Action,
 		)
 	}
-	return dispatch[*github.CheckSuiteEvent](ctx, deliveryID, eventName, event,
-		g.onCheckSuiteEvent[CheckSuiteEventRequestedAction],
-		g.onCheckSuiteEvent[CheckSuiteEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onCheckSuiteEvent[CheckSuiteEventRequestedAction]
+	anyHandlers := g.onCheckSuiteEvent[CheckSuiteEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.CheckSuiteEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnCheckSuiteEventReRequested registers callbacks listening to events of type github.CheckSuiteEvent and action 'rerequested'.
@@ -224,10 +226,11 @@ func (g *EventHandler) handleCheckSuiteEventReRequested(ctx context.Context, del
 			*event.Action,
 		)
 	}
-	return dispatch[*github.CheckSuiteEvent](ctx, deliveryID, eventName, event,
-		g.onCheckSuiteEvent[CheckSuiteEventReRequestedAction],
-		g.onCheckSuiteEvent[CheckSuiteEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onCheckSuiteEvent[CheckSuiteEventReRequestedAction]
+	anyHandlers := g.onCheckSuiteEvent[CheckSuiteEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.CheckSuiteEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnCheckSuiteEventAny registers callbacks listening to any events of type github.CheckSuiteEvent
@@ -280,7 +283,10 @@ func (g *EventHandler) handleCheckSuiteEventAny(ctx context.Context, deliveryID 
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.CheckSuiteEvent](ctx, deliveryID, eventName, event, g.onCheckSuiteEvent[CheckSuiteEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onCheckSuiteEvent[CheckSuiteEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.CheckSuiteEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // CheckSuiteEvent handles github.CheckSuiteEvent.

--- a/githubevents/events_commit_comment.go
+++ b/githubevents/events_commit_comment.go
@@ -90,10 +90,11 @@ func (g *EventHandler) handleCommitCommentEventCreated(ctx context.Context, deli
 			*event.Action,
 		)
 	}
-	return dispatch[*github.CommitCommentEvent](ctx, deliveryID, eventName, event,
-		g.onCommitCommentEvent[CommitCommentEventCreatedAction],
-		g.onCommitCommentEvent[CommitCommentEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onCommitCommentEvent[CommitCommentEventCreatedAction]
+	anyHandlers := g.onCommitCommentEvent[CommitCommentEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.CommitCommentEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnCommitCommentEventAny registers callbacks listening to any events of type github.CommitCommentEvent
@@ -146,7 +147,10 @@ func (g *EventHandler) handleCommitCommentEventAny(ctx context.Context, delivery
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.CommitCommentEvent](ctx, deliveryID, eventName, event, g.onCommitCommentEvent[CommitCommentEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onCommitCommentEvent[CommitCommentEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.CommitCommentEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // CommitCommentEvent handles github.CommitCommentEvent.

--- a/githubevents/events_create.go
+++ b/githubevents/events_create.go
@@ -79,7 +79,10 @@ func (g *EventHandler) handleCreateEventAny(ctx context.Context, deliveryID stri
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.CreateEvent](ctx, deliveryID, eventName, event, g.onCreateEvent[CreateEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onCreateEvent[CreateEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.CreateEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // CreateEvent handles github.CreateEvent.

--- a/githubevents/events_custom_property.go
+++ b/githubevents/events_custom_property.go
@@ -102,10 +102,11 @@ func (g *EventHandler) handleCustomPropertyEventCreated(ctx context.Context, del
 			*event.Action,
 		)
 	}
-	return dispatch[*github.CustomPropertyEvent](ctx, deliveryID, eventName, event,
-		g.onCustomPropertyEvent[CustomPropertyEventCreatedAction],
-		g.onCustomPropertyEvent[CustomPropertyEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onCustomPropertyEvent[CustomPropertyEventCreatedAction]
+	anyHandlers := g.onCustomPropertyEvent[CustomPropertyEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.CustomPropertyEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnCustomPropertyDeleted registers callbacks listening to events of type github.CustomPropertyEvent and action 'deleted'.
@@ -165,10 +166,11 @@ func (g *EventHandler) handleCustomPropertyDeleted(ctx context.Context, delivery
 			*event.Action,
 		)
 	}
-	return dispatch[*github.CustomPropertyEvent](ctx, deliveryID, eventName, event,
-		g.onCustomPropertyEvent[CustomPropertyDeletedAction],
-		g.onCustomPropertyEvent[CustomPropertyEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onCustomPropertyEvent[CustomPropertyDeletedAction]
+	anyHandlers := g.onCustomPropertyEvent[CustomPropertyEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.CustomPropertyEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnCustomPropertyEventPromoteToEnterprise registers callbacks listening to events of type github.CustomPropertyEvent and action 'promote_to_enterprise'.
@@ -228,10 +230,11 @@ func (g *EventHandler) handleCustomPropertyEventPromoteToEnterprise(ctx context.
 			*event.Action,
 		)
 	}
-	return dispatch[*github.CustomPropertyEvent](ctx, deliveryID, eventName, event,
-		g.onCustomPropertyEvent[CustomPropertyEventPromoteToEnterpriseAction],
-		g.onCustomPropertyEvent[CustomPropertyEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onCustomPropertyEvent[CustomPropertyEventPromoteToEnterpriseAction]
+	anyHandlers := g.onCustomPropertyEvent[CustomPropertyEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.CustomPropertyEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnCustomPropertyEventUpdated registers callbacks listening to events of type github.CustomPropertyEvent and action 'updated'.
@@ -291,10 +294,11 @@ func (g *EventHandler) handleCustomPropertyEventUpdated(ctx context.Context, del
 			*event.Action,
 		)
 	}
-	return dispatch[*github.CustomPropertyEvent](ctx, deliveryID, eventName, event,
-		g.onCustomPropertyEvent[CustomPropertyEventUpdatedAction],
-		g.onCustomPropertyEvent[CustomPropertyEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onCustomPropertyEvent[CustomPropertyEventUpdatedAction]
+	anyHandlers := g.onCustomPropertyEvent[CustomPropertyEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.CustomPropertyEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnCustomPropertyEventAny registers callbacks listening to any events of type github.CustomPropertyEvent
@@ -347,7 +351,10 @@ func (g *EventHandler) handleCustomPropertyEventAny(ctx context.Context, deliver
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.CustomPropertyEvent](ctx, deliveryID, eventName, event, g.onCustomPropertyEvent[CustomPropertyEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onCustomPropertyEvent[CustomPropertyEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.CustomPropertyEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // CustomPropertyEvent handles github.CustomPropertyEvent.

--- a/githubevents/events_custom_property_values.go
+++ b/githubevents/events_custom_property_values.go
@@ -90,10 +90,11 @@ func (g *EventHandler) handleCustomPropertyValuesEventUpdated(ctx context.Contex
 			*event.Action,
 		)
 	}
-	return dispatch[*github.CustomPropertyValuesEvent](ctx, deliveryID, eventName, event,
-		g.onCustomPropertyValuesEvent[CustomPropertyValuesEventUpdatedAction],
-		g.onCustomPropertyValuesEvent[CustomPropertyValuesEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onCustomPropertyValuesEvent[CustomPropertyValuesEventUpdatedAction]
+	anyHandlers := g.onCustomPropertyValuesEvent[CustomPropertyValuesEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.CustomPropertyValuesEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnCustomPropertyValuesEventAny registers callbacks listening to any events of type github.CustomPropertyValuesEvent
@@ -146,7 +147,10 @@ func (g *EventHandler) handleCustomPropertyValuesEventAny(ctx context.Context, d
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.CustomPropertyValuesEvent](ctx, deliveryID, eventName, event, g.onCustomPropertyValuesEvent[CustomPropertyValuesEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onCustomPropertyValuesEvent[CustomPropertyValuesEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.CustomPropertyValuesEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // CustomPropertyValuesEvent handles github.CustomPropertyValuesEvent.

--- a/githubevents/events_delete.go
+++ b/githubevents/events_delete.go
@@ -79,7 +79,10 @@ func (g *EventHandler) handleDeleteEventAny(ctx context.Context, deliveryID stri
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.DeleteEvent](ctx, deliveryID, eventName, event, g.onDeleteEvent[DeleteEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onDeleteEvent[DeleteEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.DeleteEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // DeleteEvent handles github.DeleteEvent.

--- a/githubevents/events_deploy_key.go
+++ b/githubevents/events_deploy_key.go
@@ -94,10 +94,11 @@ func (g *EventHandler) handleDeployKeyEventCreated(ctx context.Context, delivery
 			*event.Action,
 		)
 	}
-	return dispatch[*github.DeployKeyEvent](ctx, deliveryID, eventName, event,
-		g.onDeployKeyEvent[DeployKeyEventCreatedAction],
-		g.onDeployKeyEvent[DeployKeyEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onDeployKeyEvent[DeployKeyEventCreatedAction]
+	anyHandlers := g.onDeployKeyEvent[DeployKeyEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.DeployKeyEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnDeployKeyEventDeleted registers callbacks listening to events of type github.DeployKeyEvent and action 'deleted'.
@@ -157,10 +158,11 @@ func (g *EventHandler) handleDeployKeyEventDeleted(ctx context.Context, delivery
 			*event.Action,
 		)
 	}
-	return dispatch[*github.DeployKeyEvent](ctx, deliveryID, eventName, event,
-		g.onDeployKeyEvent[DeployKeyEventDeletedAction],
-		g.onDeployKeyEvent[DeployKeyEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onDeployKeyEvent[DeployKeyEventDeletedAction]
+	anyHandlers := g.onDeployKeyEvent[DeployKeyEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.DeployKeyEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnDeployKeyEventAny registers callbacks listening to any events of type github.DeployKeyEvent
@@ -213,7 +215,10 @@ func (g *EventHandler) handleDeployKeyEventAny(ctx context.Context, deliveryID s
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.DeployKeyEvent](ctx, deliveryID, eventName, event, g.onDeployKeyEvent[DeployKeyEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onDeployKeyEvent[DeployKeyEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.DeployKeyEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // DeployKeyEvent handles github.DeployKeyEvent.

--- a/githubevents/events_deployment.go
+++ b/githubevents/events_deployment.go
@@ -79,7 +79,10 @@ func (g *EventHandler) handleDeploymentEventAny(ctx context.Context, deliveryID 
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.DeploymentEvent](ctx, deliveryID, eventName, event, g.onDeploymentEvent[DeploymentEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onDeploymentEvent[DeploymentEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.DeploymentEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // DeploymentEvent handles github.DeploymentEvent.

--- a/githubevents/events_deployment_status.go
+++ b/githubevents/events_deployment_status.go
@@ -79,7 +79,10 @@ func (g *EventHandler) handleDeploymentStatusEventAny(ctx context.Context, deliv
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.DeploymentStatusEvent](ctx, deliveryID, eventName, event, g.onDeploymentStatusEvent[DeploymentStatusEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onDeploymentStatusEvent[DeploymentStatusEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.DeploymentStatusEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // DeploymentStatusEvent handles github.DeploymentStatusEvent.

--- a/githubevents/events_discussion.go
+++ b/githubevents/events_discussion.go
@@ -138,10 +138,11 @@ func (g *EventHandler) handleDiscussionEventCreated(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event,
-		g.onDiscussionEvent[DiscussionEventCreatedAction],
-		g.onDiscussionEvent[DiscussionEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onDiscussionEvent[DiscussionEventCreatedAction]
+	anyHandlers := g.onDiscussionEvent[DiscussionEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnDiscussionEventEdited registers callbacks listening to events of type github.DiscussionEvent and action 'edited'.
@@ -201,10 +202,11 @@ func (g *EventHandler) handleDiscussionEventEdited(ctx context.Context, delivery
 			*event.Action,
 		)
 	}
-	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event,
-		g.onDiscussionEvent[DiscussionEventEditedAction],
-		g.onDiscussionEvent[DiscussionEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onDiscussionEvent[DiscussionEventEditedAction]
+	anyHandlers := g.onDiscussionEvent[DiscussionEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnDiscussionEventDeleted registers callbacks listening to events of type github.DiscussionEvent and action 'deleted'.
@@ -264,10 +266,11 @@ func (g *EventHandler) handleDiscussionEventDeleted(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event,
-		g.onDiscussionEvent[DiscussionEventDeletedAction],
-		g.onDiscussionEvent[DiscussionEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onDiscussionEvent[DiscussionEventDeletedAction]
+	anyHandlers := g.onDiscussionEvent[DiscussionEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnDiscussionEventPinned registers callbacks listening to events of type github.DiscussionEvent and action 'pinned'.
@@ -327,10 +330,11 @@ func (g *EventHandler) handleDiscussionEventPinned(ctx context.Context, delivery
 			*event.Action,
 		)
 	}
-	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event,
-		g.onDiscussionEvent[DiscussionEventPinnedAction],
-		g.onDiscussionEvent[DiscussionEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onDiscussionEvent[DiscussionEventPinnedAction]
+	anyHandlers := g.onDiscussionEvent[DiscussionEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnDiscussionEventUnpinned registers callbacks listening to events of type github.DiscussionEvent and action 'unpinned'.
@@ -390,10 +394,11 @@ func (g *EventHandler) handleDiscussionEventUnpinned(ctx context.Context, delive
 			*event.Action,
 		)
 	}
-	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event,
-		g.onDiscussionEvent[DiscussionEventUnpinnedAction],
-		g.onDiscussionEvent[DiscussionEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onDiscussionEvent[DiscussionEventUnpinnedAction]
+	anyHandlers := g.onDiscussionEvent[DiscussionEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnDiscussionEventLocked registers callbacks listening to events of type github.DiscussionEvent and action 'locked'.
@@ -453,10 +458,11 @@ func (g *EventHandler) handleDiscussionEventLocked(ctx context.Context, delivery
 			*event.Action,
 		)
 	}
-	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event,
-		g.onDiscussionEvent[DiscussionEventLockedAction],
-		g.onDiscussionEvent[DiscussionEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onDiscussionEvent[DiscussionEventLockedAction]
+	anyHandlers := g.onDiscussionEvent[DiscussionEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnDiscussionEventUnlocked registers callbacks listening to events of type github.DiscussionEvent and action 'unlocked'.
@@ -516,10 +522,11 @@ func (g *EventHandler) handleDiscussionEventUnlocked(ctx context.Context, delive
 			*event.Action,
 		)
 	}
-	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event,
-		g.onDiscussionEvent[DiscussionEventUnlockedAction],
-		g.onDiscussionEvent[DiscussionEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onDiscussionEvent[DiscussionEventUnlockedAction]
+	anyHandlers := g.onDiscussionEvent[DiscussionEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnDiscussionEventTransferred registers callbacks listening to events of type github.DiscussionEvent and action 'transferred'.
@@ -579,10 +586,11 @@ func (g *EventHandler) handleDiscussionEventTransferred(ctx context.Context, del
 			*event.Action,
 		)
 	}
-	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event,
-		g.onDiscussionEvent[DiscussionEventTransferredAction],
-		g.onDiscussionEvent[DiscussionEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onDiscussionEvent[DiscussionEventTransferredAction]
+	anyHandlers := g.onDiscussionEvent[DiscussionEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnDiscussionEventCategoryChanged registers callbacks listening to events of type github.DiscussionEvent and action 'category_changed'.
@@ -642,10 +650,11 @@ func (g *EventHandler) handleDiscussionEventCategoryChanged(ctx context.Context,
 			*event.Action,
 		)
 	}
-	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event,
-		g.onDiscussionEvent[DiscussionEventCategoryChangedAction],
-		g.onDiscussionEvent[DiscussionEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onDiscussionEvent[DiscussionEventCategoryChangedAction]
+	anyHandlers := g.onDiscussionEvent[DiscussionEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnDiscussionEventAnswered registers callbacks listening to events of type github.DiscussionEvent and action 'answered'.
@@ -705,10 +714,11 @@ func (g *EventHandler) handleDiscussionEventAnswered(ctx context.Context, delive
 			*event.Action,
 		)
 	}
-	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event,
-		g.onDiscussionEvent[DiscussionEventAnsweredAction],
-		g.onDiscussionEvent[DiscussionEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onDiscussionEvent[DiscussionEventAnsweredAction]
+	anyHandlers := g.onDiscussionEvent[DiscussionEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnDiscussionEventUnanswered registers callbacks listening to events of type github.DiscussionEvent and action 'unanswered'.
@@ -768,10 +778,11 @@ func (g *EventHandler) handleDiscussionEventUnanswered(ctx context.Context, deli
 			*event.Action,
 		)
 	}
-	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event,
-		g.onDiscussionEvent[DiscussionEventUnansweredAction],
-		g.onDiscussionEvent[DiscussionEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onDiscussionEvent[DiscussionEventUnansweredAction]
+	anyHandlers := g.onDiscussionEvent[DiscussionEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnDiscussionEventLabeled registers callbacks listening to events of type github.DiscussionEvent and action 'labeled'.
@@ -831,10 +842,11 @@ func (g *EventHandler) handleDiscussionEventLabeled(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event,
-		g.onDiscussionEvent[DiscussionEventLabeledAction],
-		g.onDiscussionEvent[DiscussionEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onDiscussionEvent[DiscussionEventLabeledAction]
+	anyHandlers := g.onDiscussionEvent[DiscussionEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnDiscussionEventUnlabeled registers callbacks listening to events of type github.DiscussionEvent and action 'unlabeled'.
@@ -894,10 +906,11 @@ func (g *EventHandler) handleDiscussionEventUnlabeled(ctx context.Context, deliv
 			*event.Action,
 		)
 	}
-	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event,
-		g.onDiscussionEvent[DiscussionEventUnlabeledAction],
-		g.onDiscussionEvent[DiscussionEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onDiscussionEvent[DiscussionEventUnlabeledAction]
+	anyHandlers := g.onDiscussionEvent[DiscussionEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnDiscussionEventAny registers callbacks listening to any events of type github.DiscussionEvent
@@ -950,7 +963,10 @@ func (g *EventHandler) handleDiscussionEventAny(ctx context.Context, deliveryID 
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event, g.onDiscussionEvent[DiscussionEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onDiscussionEvent[DiscussionEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.DiscussionEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // DiscussionEvent handles github.DiscussionEvent.

--- a/githubevents/events_fork.go
+++ b/githubevents/events_fork.go
@@ -79,7 +79,10 @@ func (g *EventHandler) handleForkEventAny(ctx context.Context, deliveryID string
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.ForkEvent](ctx, deliveryID, eventName, event, g.onForkEvent[ForkEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onForkEvent[ForkEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.ForkEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // ForkEvent handles github.ForkEvent.

--- a/githubevents/events_github_app_authorization.go
+++ b/githubevents/events_github_app_authorization.go
@@ -90,10 +90,11 @@ func (g *EventHandler) handleGitHubAppAuthorizationEventRevoked(ctx context.Cont
 			*event.Action,
 		)
 	}
-	return dispatch[*github.GitHubAppAuthorizationEvent](ctx, deliveryID, eventName, event,
-		g.onGitHubAppAuthorizationEvent[GitHubAppAuthorizationEventRevokedAction],
-		g.onGitHubAppAuthorizationEvent[GitHubAppAuthorizationEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onGitHubAppAuthorizationEvent[GitHubAppAuthorizationEventRevokedAction]
+	anyHandlers := g.onGitHubAppAuthorizationEvent[GitHubAppAuthorizationEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.GitHubAppAuthorizationEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnGitHubAppAuthorizationEventAny registers callbacks listening to any events of type github.GitHubAppAuthorizationEvent
@@ -146,7 +147,10 @@ func (g *EventHandler) handleGitHubAppAuthorizationEventAny(ctx context.Context,
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.GitHubAppAuthorizationEvent](ctx, deliveryID, eventName, event, g.onGitHubAppAuthorizationEvent[GitHubAppAuthorizationEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onGitHubAppAuthorizationEvent[GitHubAppAuthorizationEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.GitHubAppAuthorizationEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // GitHubAppAuthorizationEvent handles github.GitHubAppAuthorizationEvent.

--- a/githubevents/events_gollum.go
+++ b/githubevents/events_gollum.go
@@ -79,7 +79,10 @@ func (g *EventHandler) handleGollumEventAny(ctx context.Context, deliveryID stri
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.GollumEvent](ctx, deliveryID, eventName, event, g.onGollumEvent[GollumEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onGollumEvent[GollumEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.GollumEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // GollumEvent handles github.GollumEvent.

--- a/githubevents/events_installation.go
+++ b/githubevents/events_installation.go
@@ -106,10 +106,11 @@ func (g *EventHandler) handleInstallationEventCreated(ctx context.Context, deliv
 			*event.Action,
 		)
 	}
-	return dispatch[*github.InstallationEvent](ctx, deliveryID, eventName, event,
-		g.onInstallationEvent[InstallationEventCreatedAction],
-		g.onInstallationEvent[InstallationEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onInstallationEvent[InstallationEventCreatedAction]
+	anyHandlers := g.onInstallationEvent[InstallationEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.InstallationEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnInstallationEventDeleted registers callbacks listening to events of type github.InstallationEvent and action 'deleted'.
@@ -169,10 +170,11 @@ func (g *EventHandler) handleInstallationEventDeleted(ctx context.Context, deliv
 			*event.Action,
 		)
 	}
-	return dispatch[*github.InstallationEvent](ctx, deliveryID, eventName, event,
-		g.onInstallationEvent[InstallationEventDeletedAction],
-		g.onInstallationEvent[InstallationEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onInstallationEvent[InstallationEventDeletedAction]
+	anyHandlers := g.onInstallationEvent[InstallationEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.InstallationEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnInstallationEventEventSuspend registers callbacks listening to events of type github.InstallationEvent and action 'suspend'.
@@ -232,10 +234,11 @@ func (g *EventHandler) handleInstallationEventEventSuspend(ctx context.Context, 
 			*event.Action,
 		)
 	}
-	return dispatch[*github.InstallationEvent](ctx, deliveryID, eventName, event,
-		g.onInstallationEvent[InstallationEventEventSuspendAction],
-		g.onInstallationEvent[InstallationEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onInstallationEvent[InstallationEventEventSuspendAction]
+	anyHandlers := g.onInstallationEvent[InstallationEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.InstallationEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnInstallationEventEventUnsuspend registers callbacks listening to events of type github.InstallationEvent and action 'unsuspend'.
@@ -295,10 +298,11 @@ func (g *EventHandler) handleInstallationEventEventUnsuspend(ctx context.Context
 			*event.Action,
 		)
 	}
-	return dispatch[*github.InstallationEvent](ctx, deliveryID, eventName, event,
-		g.onInstallationEvent[InstallationEventEventUnsuspendAction],
-		g.onInstallationEvent[InstallationEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onInstallationEvent[InstallationEventEventUnsuspendAction]
+	anyHandlers := g.onInstallationEvent[InstallationEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.InstallationEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnInstallationEventNewPermissionsAccepted registers callbacks listening to events of type github.InstallationEvent and action 'new_permissions_accepted'.
@@ -358,10 +362,11 @@ func (g *EventHandler) handleInstallationEventNewPermissionsAccepted(ctx context
 			*event.Action,
 		)
 	}
-	return dispatch[*github.InstallationEvent](ctx, deliveryID, eventName, event,
-		g.onInstallationEvent[InstallationEventNewPermissionsAcceptedAction],
-		g.onInstallationEvent[InstallationEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onInstallationEvent[InstallationEventNewPermissionsAcceptedAction]
+	anyHandlers := g.onInstallationEvent[InstallationEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.InstallationEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnInstallationEventAny registers callbacks listening to any events of type github.InstallationEvent
@@ -414,7 +419,10 @@ func (g *EventHandler) handleInstallationEventAny(ctx context.Context, deliveryI
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.InstallationEvent](ctx, deliveryID, eventName, event, g.onInstallationEvent[InstallationEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onInstallationEvent[InstallationEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.InstallationEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // InstallationEvent handles github.InstallationEvent.

--- a/githubevents/events_installation_repositories.go
+++ b/githubevents/events_installation_repositories.go
@@ -94,10 +94,11 @@ func (g *EventHandler) handleInstallationRepositoriesEventAdded(ctx context.Cont
 			*event.Action,
 		)
 	}
-	return dispatch[*github.InstallationRepositoriesEvent](ctx, deliveryID, eventName, event,
-		g.onInstallationRepositoriesEvent[InstallationRepositoriesEventAddedAction],
-		g.onInstallationRepositoriesEvent[InstallationRepositoriesEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onInstallationRepositoriesEvent[InstallationRepositoriesEventAddedAction]
+	anyHandlers := g.onInstallationRepositoriesEvent[InstallationRepositoriesEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.InstallationRepositoriesEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnInstallationRepositoriesEventRemoved registers callbacks listening to events of type github.InstallationRepositoriesEvent and action 'removed'.
@@ -157,10 +158,11 @@ func (g *EventHandler) handleInstallationRepositoriesEventRemoved(ctx context.Co
 			*event.Action,
 		)
 	}
-	return dispatch[*github.InstallationRepositoriesEvent](ctx, deliveryID, eventName, event,
-		g.onInstallationRepositoriesEvent[InstallationRepositoriesEventRemovedAction],
-		g.onInstallationRepositoriesEvent[InstallationRepositoriesEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onInstallationRepositoriesEvent[InstallationRepositoriesEventRemovedAction]
+	anyHandlers := g.onInstallationRepositoriesEvent[InstallationRepositoriesEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.InstallationRepositoriesEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnInstallationRepositoriesEventAny registers callbacks listening to any events of type github.InstallationRepositoriesEvent
@@ -213,7 +215,10 @@ func (g *EventHandler) handleInstallationRepositoriesEventAny(ctx context.Contex
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.InstallationRepositoriesEvent](ctx, deliveryID, eventName, event, g.onInstallationRepositoriesEvent[InstallationRepositoriesEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onInstallationRepositoriesEvent[InstallationRepositoriesEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.InstallationRepositoriesEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // InstallationRepositoriesEvent handles github.InstallationRepositoriesEvent.

--- a/githubevents/events_issue_comment.go
+++ b/githubevents/events_issue_comment.go
@@ -98,10 +98,11 @@ func (g *EventHandler) handleIssueCommentCreated(ctx context.Context, deliveryID
 			*event.Action,
 		)
 	}
-	return dispatch[*github.IssueCommentEvent](ctx, deliveryID, eventName, event,
-		g.onIssueCommentEvent[IssueCommentCreatedAction],
-		g.onIssueCommentEvent[IssueCommentEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onIssueCommentEvent[IssueCommentCreatedAction]
+	anyHandlers := g.onIssueCommentEvent[IssueCommentEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.IssueCommentEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnIssueCommentEdited registers callbacks listening to events of type github.IssueCommentEvent and action 'edited'.
@@ -161,10 +162,11 @@ func (g *EventHandler) handleIssueCommentEdited(ctx context.Context, deliveryID 
 			*event.Action,
 		)
 	}
-	return dispatch[*github.IssueCommentEvent](ctx, deliveryID, eventName, event,
-		g.onIssueCommentEvent[IssueCommentEditedAction],
-		g.onIssueCommentEvent[IssueCommentEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onIssueCommentEvent[IssueCommentEditedAction]
+	anyHandlers := g.onIssueCommentEvent[IssueCommentEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.IssueCommentEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnIssueCommentDeleted registers callbacks listening to events of type github.IssueCommentEvent and action 'deleted'.
@@ -224,10 +226,11 @@ func (g *EventHandler) handleIssueCommentDeleted(ctx context.Context, deliveryID
 			*event.Action,
 		)
 	}
-	return dispatch[*github.IssueCommentEvent](ctx, deliveryID, eventName, event,
-		g.onIssueCommentEvent[IssueCommentDeletedAction],
-		g.onIssueCommentEvent[IssueCommentEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onIssueCommentEvent[IssueCommentDeletedAction]
+	anyHandlers := g.onIssueCommentEvent[IssueCommentEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.IssueCommentEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnIssueCommentEventAny registers callbacks listening to any events of type github.IssueCommentEvent
@@ -280,7 +283,10 @@ func (g *EventHandler) handleIssueCommentEventAny(ctx context.Context, deliveryI
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.IssueCommentEvent](ctx, deliveryID, eventName, event, g.onIssueCommentEvent[IssueCommentEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onIssueCommentEvent[IssueCommentEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.IssueCommentEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // IssueCommentEvent handles github.IssueCommentEvent.

--- a/githubevents/events_issues.go
+++ b/githubevents/events_issues.go
@@ -150,10 +150,11 @@ func (g *EventHandler) handleIssuesEventOpened(ctx context.Context, deliveryID s
 			*event.Action,
 		)
 	}
-	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
-		g.onIssuesEvent[IssuesEventOpenedAction],
-		g.onIssuesEvent[IssuesEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onIssuesEvent[IssuesEventOpenedAction]
+	anyHandlers := g.onIssuesEvent[IssuesEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnIssuesEventEdited registers callbacks listening to events of type github.IssuesEvent and action 'edited'.
@@ -213,10 +214,11 @@ func (g *EventHandler) handleIssuesEventEdited(ctx context.Context, deliveryID s
 			*event.Action,
 		)
 	}
-	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
-		g.onIssuesEvent[IssuesEventEditedAction],
-		g.onIssuesEvent[IssuesEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onIssuesEvent[IssuesEventEditedAction]
+	anyHandlers := g.onIssuesEvent[IssuesEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnIssuesEventDeleted registers callbacks listening to events of type github.IssuesEvent and action 'deleted'.
@@ -276,10 +278,11 @@ func (g *EventHandler) handleIssuesEventDeleted(ctx context.Context, deliveryID 
 			*event.Action,
 		)
 	}
-	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
-		g.onIssuesEvent[IssuesEventDeletedAction],
-		g.onIssuesEvent[IssuesEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onIssuesEvent[IssuesEventDeletedAction]
+	anyHandlers := g.onIssuesEvent[IssuesEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnIssuesEventPinned registers callbacks listening to events of type github.IssuesEvent and action 'pinned'.
@@ -339,10 +342,11 @@ func (g *EventHandler) handleIssuesEventPinned(ctx context.Context, deliveryID s
 			*event.Action,
 		)
 	}
-	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
-		g.onIssuesEvent[IssuesEventPinnedAction],
-		g.onIssuesEvent[IssuesEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onIssuesEvent[IssuesEventPinnedAction]
+	anyHandlers := g.onIssuesEvent[IssuesEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnIssuesEventUnpinned registers callbacks listening to events of type github.IssuesEvent and action 'unpinned'.
@@ -402,10 +406,11 @@ func (g *EventHandler) handleIssuesEventUnpinned(ctx context.Context, deliveryID
 			*event.Action,
 		)
 	}
-	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
-		g.onIssuesEvent[IssuesEventUnpinnedAction],
-		g.onIssuesEvent[IssuesEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onIssuesEvent[IssuesEventUnpinnedAction]
+	anyHandlers := g.onIssuesEvent[IssuesEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnIssuesEventClosed registers callbacks listening to events of type github.IssuesEvent and action 'closed'.
@@ -465,10 +470,11 @@ func (g *EventHandler) handleIssuesEventClosed(ctx context.Context, deliveryID s
 			*event.Action,
 		)
 	}
-	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
-		g.onIssuesEvent[IssuesEventClosedAction],
-		g.onIssuesEvent[IssuesEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onIssuesEvent[IssuesEventClosedAction]
+	anyHandlers := g.onIssuesEvent[IssuesEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnIssuesEventReopened registers callbacks listening to events of type github.IssuesEvent and action 'reopened'.
@@ -528,10 +534,11 @@ func (g *EventHandler) handleIssuesEventReopened(ctx context.Context, deliveryID
 			*event.Action,
 		)
 	}
-	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
-		g.onIssuesEvent[IssuesEventReopenedAction],
-		g.onIssuesEvent[IssuesEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onIssuesEvent[IssuesEventReopenedAction]
+	anyHandlers := g.onIssuesEvent[IssuesEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnIssuesEventAssigned registers callbacks listening to events of type github.IssuesEvent and action 'assigned'.
@@ -591,10 +598,11 @@ func (g *EventHandler) handleIssuesEventAssigned(ctx context.Context, deliveryID
 			*event.Action,
 		)
 	}
-	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
-		g.onIssuesEvent[IssuesEventAssignedAction],
-		g.onIssuesEvent[IssuesEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onIssuesEvent[IssuesEventAssignedAction]
+	anyHandlers := g.onIssuesEvent[IssuesEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnIssuesEventUnassigned registers callbacks listening to events of type github.IssuesEvent and action 'unassigned'.
@@ -654,10 +662,11 @@ func (g *EventHandler) handleIssuesEventUnassigned(ctx context.Context, delivery
 			*event.Action,
 		)
 	}
-	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
-		g.onIssuesEvent[IssuesEventUnassignedAction],
-		g.onIssuesEvent[IssuesEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onIssuesEvent[IssuesEventUnassignedAction]
+	anyHandlers := g.onIssuesEvent[IssuesEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnIssuesEventLabeled registers callbacks listening to events of type github.IssuesEvent and action 'labeled'.
@@ -717,10 +726,11 @@ func (g *EventHandler) handleIssuesEventLabeled(ctx context.Context, deliveryID 
 			*event.Action,
 		)
 	}
-	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
-		g.onIssuesEvent[IssuesEventLabeledAction],
-		g.onIssuesEvent[IssuesEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onIssuesEvent[IssuesEventLabeledAction]
+	anyHandlers := g.onIssuesEvent[IssuesEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnIssuesEventUnlabeled registers callbacks listening to events of type github.IssuesEvent and action 'unlabeled'.
@@ -780,10 +790,11 @@ func (g *EventHandler) handleIssuesEventUnlabeled(ctx context.Context, deliveryI
 			*event.Action,
 		)
 	}
-	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
-		g.onIssuesEvent[IssuesEventUnlabeledAction],
-		g.onIssuesEvent[IssuesEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onIssuesEvent[IssuesEventUnlabeledAction]
+	anyHandlers := g.onIssuesEvent[IssuesEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnIssuesEventLocked registers callbacks listening to events of type github.IssuesEvent and action 'locked'.
@@ -843,10 +854,11 @@ func (g *EventHandler) handleIssuesEventLocked(ctx context.Context, deliveryID s
 			*event.Action,
 		)
 	}
-	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
-		g.onIssuesEvent[IssuesEventLockedAction],
-		g.onIssuesEvent[IssuesEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onIssuesEvent[IssuesEventLockedAction]
+	anyHandlers := g.onIssuesEvent[IssuesEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnIssuesEventUnlocked registers callbacks listening to events of type github.IssuesEvent and action 'unlocked'.
@@ -906,10 +918,11 @@ func (g *EventHandler) handleIssuesEventUnlocked(ctx context.Context, deliveryID
 			*event.Action,
 		)
 	}
-	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
-		g.onIssuesEvent[IssuesEventUnlockedAction],
-		g.onIssuesEvent[IssuesEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onIssuesEvent[IssuesEventUnlockedAction]
+	anyHandlers := g.onIssuesEvent[IssuesEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnIssuesEventTransferred registers callbacks listening to events of type github.IssuesEvent and action 'transferred'.
@@ -969,10 +982,11 @@ func (g *EventHandler) handleIssuesEventTransferred(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
-		g.onIssuesEvent[IssuesEventTransferredAction],
-		g.onIssuesEvent[IssuesEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onIssuesEvent[IssuesEventTransferredAction]
+	anyHandlers := g.onIssuesEvent[IssuesEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnIssuesEventMilestoned registers callbacks listening to events of type github.IssuesEvent and action 'milestoned'.
@@ -1032,10 +1046,11 @@ func (g *EventHandler) handleIssuesEventMilestoned(ctx context.Context, delivery
 			*event.Action,
 		)
 	}
-	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
-		g.onIssuesEvent[IssuesEventMilestonedAction],
-		g.onIssuesEvent[IssuesEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onIssuesEvent[IssuesEventMilestonedAction]
+	anyHandlers := g.onIssuesEvent[IssuesEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnIssuesEventDeMilestoned registers callbacks listening to events of type github.IssuesEvent and action 'demilestoned'.
@@ -1095,10 +1110,11 @@ func (g *EventHandler) handleIssuesEventDeMilestoned(ctx context.Context, delive
 			*event.Action,
 		)
 	}
-	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event,
-		g.onIssuesEvent[IssuesEventDeMilestonedAction],
-		g.onIssuesEvent[IssuesEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onIssuesEvent[IssuesEventDeMilestonedAction]
+	anyHandlers := g.onIssuesEvent[IssuesEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnIssuesEventAny registers callbacks listening to any events of type github.IssuesEvent
@@ -1151,7 +1167,10 @@ func (g *EventHandler) handleIssuesEventAny(ctx context.Context, deliveryID stri
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event, g.onIssuesEvent[IssuesEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onIssuesEvent[IssuesEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.IssuesEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // IssuesEvent handles github.IssuesEvent.

--- a/githubevents/events_label.go
+++ b/githubevents/events_label.go
@@ -98,10 +98,11 @@ func (g *EventHandler) handleLabelEventCreated(ctx context.Context, deliveryID s
 			*event.Action,
 		)
 	}
-	return dispatch[*github.LabelEvent](ctx, deliveryID, eventName, event,
-		g.onLabelEvent[LabelEventCreatedAction],
-		g.onLabelEvent[LabelEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onLabelEvent[LabelEventCreatedAction]
+	anyHandlers := g.onLabelEvent[LabelEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.LabelEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnLabelEventEdited registers callbacks listening to events of type github.LabelEvent and action 'edited'.
@@ -161,10 +162,11 @@ func (g *EventHandler) handleLabelEventEdited(ctx context.Context, deliveryID st
 			*event.Action,
 		)
 	}
-	return dispatch[*github.LabelEvent](ctx, deliveryID, eventName, event,
-		g.onLabelEvent[LabelEventEditedAction],
-		g.onLabelEvent[LabelEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onLabelEvent[LabelEventEditedAction]
+	anyHandlers := g.onLabelEvent[LabelEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.LabelEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnLabelEventDeleted registers callbacks listening to events of type github.LabelEvent and action 'deleted'.
@@ -224,10 +226,11 @@ func (g *EventHandler) handleLabelEventDeleted(ctx context.Context, deliveryID s
 			*event.Action,
 		)
 	}
-	return dispatch[*github.LabelEvent](ctx, deliveryID, eventName, event,
-		g.onLabelEvent[LabelEventDeletedAction],
-		g.onLabelEvent[LabelEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onLabelEvent[LabelEventDeletedAction]
+	anyHandlers := g.onLabelEvent[LabelEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.LabelEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnLabelEventAny registers callbacks listening to any events of type github.LabelEvent
@@ -280,7 +283,10 @@ func (g *EventHandler) handleLabelEventAny(ctx context.Context, deliveryID strin
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.LabelEvent](ctx, deliveryID, eventName, event, g.onLabelEvent[LabelEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onLabelEvent[LabelEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.LabelEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // LabelEvent handles github.LabelEvent.

--- a/githubevents/events_marketplace_purchase.go
+++ b/githubevents/events_marketplace_purchase.go
@@ -106,10 +106,11 @@ func (g *EventHandler) handleMarketplacePurchaseEventPurchased(ctx context.Conte
 			*event.Action,
 		)
 	}
-	return dispatch[*github.MarketplacePurchaseEvent](ctx, deliveryID, eventName, event,
-		g.onMarketplacePurchaseEvent[MarketplacePurchaseEventPurchasedAction],
-		g.onMarketplacePurchaseEvent[MarketplacePurchaseEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onMarketplacePurchaseEvent[MarketplacePurchaseEventPurchasedAction]
+	anyHandlers := g.onMarketplacePurchaseEvent[MarketplacePurchaseEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.MarketplacePurchaseEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnMarketplacePurchaseEventPendingChange registers callbacks listening to events of type github.MarketplacePurchaseEvent and action 'pending_change'.
@@ -169,10 +170,11 @@ func (g *EventHandler) handleMarketplacePurchaseEventPendingChange(ctx context.C
 			*event.Action,
 		)
 	}
-	return dispatch[*github.MarketplacePurchaseEvent](ctx, deliveryID, eventName, event,
-		g.onMarketplacePurchaseEvent[MarketplacePurchaseEventPendingChangeAction],
-		g.onMarketplacePurchaseEvent[MarketplacePurchaseEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onMarketplacePurchaseEvent[MarketplacePurchaseEventPendingChangeAction]
+	anyHandlers := g.onMarketplacePurchaseEvent[MarketplacePurchaseEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.MarketplacePurchaseEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnMarketplacePurchaseEventPendingChangeCanceled registers callbacks listening to events of type github.MarketplacePurchaseEvent and action 'pending_change_canceled'.
@@ -232,10 +234,11 @@ func (g *EventHandler) handleMarketplacePurchaseEventPendingChangeCanceled(ctx c
 			*event.Action,
 		)
 	}
-	return dispatch[*github.MarketplacePurchaseEvent](ctx, deliveryID, eventName, event,
-		g.onMarketplacePurchaseEvent[MarketplacePurchaseEventPendingChangeCanceledAction],
-		g.onMarketplacePurchaseEvent[MarketplacePurchaseEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onMarketplacePurchaseEvent[MarketplacePurchaseEventPendingChangeCanceledAction]
+	anyHandlers := g.onMarketplacePurchaseEvent[MarketplacePurchaseEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.MarketplacePurchaseEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnMarketplacePurchaseEventChanged registers callbacks listening to events of type github.MarketplacePurchaseEvent and action 'changed'.
@@ -295,10 +298,11 @@ func (g *EventHandler) handleMarketplacePurchaseEventChanged(ctx context.Context
 			*event.Action,
 		)
 	}
-	return dispatch[*github.MarketplacePurchaseEvent](ctx, deliveryID, eventName, event,
-		g.onMarketplacePurchaseEvent[MarketplacePurchaseEventChangedAction],
-		g.onMarketplacePurchaseEvent[MarketplacePurchaseEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onMarketplacePurchaseEvent[MarketplacePurchaseEventChangedAction]
+	anyHandlers := g.onMarketplacePurchaseEvent[MarketplacePurchaseEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.MarketplacePurchaseEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnMarketplacePurchaseEventCanceled registers callbacks listening to events of type github.MarketplacePurchaseEvent and action 'canceled'.
@@ -358,10 +362,11 @@ func (g *EventHandler) handleMarketplacePurchaseEventCanceled(ctx context.Contex
 			*event.Action,
 		)
 	}
-	return dispatch[*github.MarketplacePurchaseEvent](ctx, deliveryID, eventName, event,
-		g.onMarketplacePurchaseEvent[MarketplacePurchaseEventCanceledAction],
-		g.onMarketplacePurchaseEvent[MarketplacePurchaseEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onMarketplacePurchaseEvent[MarketplacePurchaseEventCanceledAction]
+	anyHandlers := g.onMarketplacePurchaseEvent[MarketplacePurchaseEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.MarketplacePurchaseEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnMarketplacePurchaseEventAny registers callbacks listening to any events of type github.MarketplacePurchaseEvent
@@ -414,7 +419,10 @@ func (g *EventHandler) handleMarketplacePurchaseEventAny(ctx context.Context, de
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.MarketplacePurchaseEvent](ctx, deliveryID, eventName, event, g.onMarketplacePurchaseEvent[MarketplacePurchaseEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onMarketplacePurchaseEvent[MarketplacePurchaseEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.MarketplacePurchaseEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // MarketplacePurchaseEvent handles github.MarketplacePurchaseEvent.

--- a/githubevents/events_member.go
+++ b/githubevents/events_member.go
@@ -98,10 +98,11 @@ func (g *EventHandler) handleMemberEventAdded(ctx context.Context, deliveryID st
 			*event.Action,
 		)
 	}
-	return dispatch[*github.MemberEvent](ctx, deliveryID, eventName, event,
-		g.onMemberEvent[MemberEventAddedAction],
-		g.onMemberEvent[MemberEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onMemberEvent[MemberEventAddedAction]
+	anyHandlers := g.onMemberEvent[MemberEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.MemberEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnMemberEventRemoved registers callbacks listening to events of type github.MemberEvent and action 'removed'.
@@ -161,10 +162,11 @@ func (g *EventHandler) handleMemberEventRemoved(ctx context.Context, deliveryID 
 			*event.Action,
 		)
 	}
-	return dispatch[*github.MemberEvent](ctx, deliveryID, eventName, event,
-		g.onMemberEvent[MemberEventRemovedAction],
-		g.onMemberEvent[MemberEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onMemberEvent[MemberEventRemovedAction]
+	anyHandlers := g.onMemberEvent[MemberEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.MemberEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnMemberEventEdited registers callbacks listening to events of type github.MemberEvent and action 'edited'.
@@ -224,10 +226,11 @@ func (g *EventHandler) handleMemberEventEdited(ctx context.Context, deliveryID s
 			*event.Action,
 		)
 	}
-	return dispatch[*github.MemberEvent](ctx, deliveryID, eventName, event,
-		g.onMemberEvent[MemberEventEditedAction],
-		g.onMemberEvent[MemberEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onMemberEvent[MemberEventEditedAction]
+	anyHandlers := g.onMemberEvent[MemberEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.MemberEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnMemberEventAny registers callbacks listening to any events of type github.MemberEvent
@@ -280,7 +283,10 @@ func (g *EventHandler) handleMemberEventAny(ctx context.Context, deliveryID stri
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.MemberEvent](ctx, deliveryID, eventName, event, g.onMemberEvent[MemberEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onMemberEvent[MemberEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.MemberEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // MemberEvent handles github.MemberEvent.

--- a/githubevents/events_membership.go
+++ b/githubevents/events_membership.go
@@ -94,10 +94,11 @@ func (g *EventHandler) handleMembershipEventAdded(ctx context.Context, deliveryI
 			*event.Action,
 		)
 	}
-	return dispatch[*github.MembershipEvent](ctx, deliveryID, eventName, event,
-		g.onMembershipEvent[MembershipEventAddedAction],
-		g.onMembershipEvent[MembershipEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onMembershipEvent[MembershipEventAddedAction]
+	anyHandlers := g.onMembershipEvent[MembershipEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.MembershipEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnMembershipEventRemoved registers callbacks listening to events of type github.MembershipEvent and action 'removed'.
@@ -157,10 +158,11 @@ func (g *EventHandler) handleMembershipEventRemoved(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	return dispatch[*github.MembershipEvent](ctx, deliveryID, eventName, event,
-		g.onMembershipEvent[MembershipEventRemovedAction],
-		g.onMembershipEvent[MembershipEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onMembershipEvent[MembershipEventRemovedAction]
+	anyHandlers := g.onMembershipEvent[MembershipEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.MembershipEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnMembershipEventAny registers callbacks listening to any events of type github.MembershipEvent
@@ -213,7 +215,10 @@ func (g *EventHandler) handleMembershipEventAny(ctx context.Context, deliveryID 
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.MembershipEvent](ctx, deliveryID, eventName, event, g.onMembershipEvent[MembershipEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onMembershipEvent[MembershipEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.MembershipEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // MembershipEvent handles github.MembershipEvent.

--- a/githubevents/events_merge_group_event.go
+++ b/githubevents/events_merge_group_event.go
@@ -94,10 +94,11 @@ func (g *EventHandler) handleMergeGroupEventChecksRequested(ctx context.Context,
 			*event.Action,
 		)
 	}
-	return dispatch[*github.MergeGroupEvent](ctx, deliveryID, eventName, event,
-		g.onMergeGroupEvent[MergeGroupEventChecksRequestedAction],
-		g.onMergeGroupEvent[MergeGroupEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onMergeGroupEvent[MergeGroupEventChecksRequestedAction]
+	anyHandlers := g.onMergeGroupEvent[MergeGroupEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.MergeGroupEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnMergeGroupEventDestroyed registers callbacks listening to events of type github.MergeGroupEvent and action 'destroyed'.
@@ -157,10 +158,11 @@ func (g *EventHandler) handleMergeGroupEventDestroyed(ctx context.Context, deliv
 			*event.Action,
 		)
 	}
-	return dispatch[*github.MergeGroupEvent](ctx, deliveryID, eventName, event,
-		g.onMergeGroupEvent[MergeGroupEventDestroyedAction],
-		g.onMergeGroupEvent[MergeGroupEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onMergeGroupEvent[MergeGroupEventDestroyedAction]
+	anyHandlers := g.onMergeGroupEvent[MergeGroupEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.MergeGroupEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnMergeGroupEventAny registers callbacks listening to any events of type github.MergeGroupEvent
@@ -213,7 +215,10 @@ func (g *EventHandler) handleMergeGroupEventAny(ctx context.Context, deliveryID 
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.MergeGroupEvent](ctx, deliveryID, eventName, event, g.onMergeGroupEvent[MergeGroupEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onMergeGroupEvent[MergeGroupEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.MergeGroupEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // MergeGroupEvent handles github.MergeGroupEvent.

--- a/githubevents/events_meta.go
+++ b/githubevents/events_meta.go
@@ -79,7 +79,10 @@ func (g *EventHandler) handleMetaEventAny(ctx context.Context, deliveryID string
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.MetaEvent](ctx, deliveryID, eventName, event, g.onMetaEvent[MetaEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onMetaEvent[MetaEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.MetaEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // MetaEvent handles github.MetaEvent.

--- a/githubevents/events_milestone.go
+++ b/githubevents/events_milestone.go
@@ -106,10 +106,11 @@ func (g *EventHandler) handleMilestoneEventCreated(ctx context.Context, delivery
 			*event.Action,
 		)
 	}
-	return dispatch[*github.MilestoneEvent](ctx, deliveryID, eventName, event,
-		g.onMilestoneEvent[MilestoneEventCreatedAction],
-		g.onMilestoneEvent[MilestoneEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onMilestoneEvent[MilestoneEventCreatedAction]
+	anyHandlers := g.onMilestoneEvent[MilestoneEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.MilestoneEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnMilestoneEventClosed registers callbacks listening to events of type github.MilestoneEvent and action 'closed'.
@@ -169,10 +170,11 @@ func (g *EventHandler) handleMilestoneEventClosed(ctx context.Context, deliveryI
 			*event.Action,
 		)
 	}
-	return dispatch[*github.MilestoneEvent](ctx, deliveryID, eventName, event,
-		g.onMilestoneEvent[MilestoneEventClosedAction],
-		g.onMilestoneEvent[MilestoneEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onMilestoneEvent[MilestoneEventClosedAction]
+	anyHandlers := g.onMilestoneEvent[MilestoneEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.MilestoneEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnMilestoneEventOpened registers callbacks listening to events of type github.MilestoneEvent and action 'opened'.
@@ -232,10 +234,11 @@ func (g *EventHandler) handleMilestoneEventOpened(ctx context.Context, deliveryI
 			*event.Action,
 		)
 	}
-	return dispatch[*github.MilestoneEvent](ctx, deliveryID, eventName, event,
-		g.onMilestoneEvent[MilestoneEventOpenedAction],
-		g.onMilestoneEvent[MilestoneEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onMilestoneEvent[MilestoneEventOpenedAction]
+	anyHandlers := g.onMilestoneEvent[MilestoneEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.MilestoneEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnMilestoneEventEdited registers callbacks listening to events of type github.MilestoneEvent and action 'edited'.
@@ -295,10 +298,11 @@ func (g *EventHandler) handleMilestoneEventEdited(ctx context.Context, deliveryI
 			*event.Action,
 		)
 	}
-	return dispatch[*github.MilestoneEvent](ctx, deliveryID, eventName, event,
-		g.onMilestoneEvent[MilestoneEventEditedAction],
-		g.onMilestoneEvent[MilestoneEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onMilestoneEvent[MilestoneEventEditedAction]
+	anyHandlers := g.onMilestoneEvent[MilestoneEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.MilestoneEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnMilestoneEventDeleted registers callbacks listening to events of type github.MilestoneEvent and action 'deleted'.
@@ -358,10 +362,11 @@ func (g *EventHandler) handleMilestoneEventDeleted(ctx context.Context, delivery
 			*event.Action,
 		)
 	}
-	return dispatch[*github.MilestoneEvent](ctx, deliveryID, eventName, event,
-		g.onMilestoneEvent[MilestoneEventDeletedAction],
-		g.onMilestoneEvent[MilestoneEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onMilestoneEvent[MilestoneEventDeletedAction]
+	anyHandlers := g.onMilestoneEvent[MilestoneEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.MilestoneEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnMilestoneEventAny registers callbacks listening to any events of type github.MilestoneEvent
@@ -414,7 +419,10 @@ func (g *EventHandler) handleMilestoneEventAny(ctx context.Context, deliveryID s
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.MilestoneEvent](ctx, deliveryID, eventName, event, g.onMilestoneEvent[MilestoneEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onMilestoneEvent[MilestoneEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.MilestoneEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // MilestoneEvent handles github.MilestoneEvent.

--- a/githubevents/events_org_block.go
+++ b/githubevents/events_org_block.go
@@ -94,10 +94,11 @@ func (g *EventHandler) handleOrgBlockEventBlocked(ctx context.Context, deliveryI
 			*event.Action,
 		)
 	}
-	return dispatch[*github.OrgBlockEvent](ctx, deliveryID, eventName, event,
-		g.onOrgBlockEvent[OrgBlockEventBlockedAction],
-		g.onOrgBlockEvent[OrgBlockEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onOrgBlockEvent[OrgBlockEventBlockedAction]
+	anyHandlers := g.onOrgBlockEvent[OrgBlockEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.OrgBlockEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnOrgBlockEventUnblocked registers callbacks listening to events of type github.OrgBlockEvent and action 'unblocked'.
@@ -157,10 +158,11 @@ func (g *EventHandler) handleOrgBlockEventUnblocked(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	return dispatch[*github.OrgBlockEvent](ctx, deliveryID, eventName, event,
-		g.onOrgBlockEvent[OrgBlockEventUnblockedAction],
-		g.onOrgBlockEvent[OrgBlockEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onOrgBlockEvent[OrgBlockEventUnblockedAction]
+	anyHandlers := g.onOrgBlockEvent[OrgBlockEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.OrgBlockEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnOrgBlockEventAny registers callbacks listening to any events of type github.OrgBlockEvent
@@ -213,7 +215,10 @@ func (g *EventHandler) handleOrgBlockEventAny(ctx context.Context, deliveryID st
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.OrgBlockEvent](ctx, deliveryID, eventName, event, g.onOrgBlockEvent[OrgBlockEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onOrgBlockEvent[OrgBlockEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.OrgBlockEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // OrgBlockEvent handles github.OrgBlockEvent.

--- a/githubevents/events_organization.go
+++ b/githubevents/events_organization.go
@@ -106,10 +106,11 @@ func (g *EventHandler) handleOrganizationEventDeleted(ctx context.Context, deliv
 			*event.Action,
 		)
 	}
-	return dispatch[*github.OrganizationEvent](ctx, deliveryID, eventName, event,
-		g.onOrganizationEvent[OrganizationEventDeletedAction],
-		g.onOrganizationEvent[OrganizationEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onOrganizationEvent[OrganizationEventDeletedAction]
+	anyHandlers := g.onOrganizationEvent[OrganizationEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.OrganizationEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnOrganizationEventRenamed registers callbacks listening to events of type github.OrganizationEvent and action 'renamed'.
@@ -169,10 +170,11 @@ func (g *EventHandler) handleOrganizationEventRenamed(ctx context.Context, deliv
 			*event.Action,
 		)
 	}
-	return dispatch[*github.OrganizationEvent](ctx, deliveryID, eventName, event,
-		g.onOrganizationEvent[OrganizationEventRenamedAction],
-		g.onOrganizationEvent[OrganizationEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onOrganizationEvent[OrganizationEventRenamedAction]
+	anyHandlers := g.onOrganizationEvent[OrganizationEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.OrganizationEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnOrganizationEventMemberAdded registers callbacks listening to events of type github.OrganizationEvent and action 'member_added'.
@@ -232,10 +234,11 @@ func (g *EventHandler) handleOrganizationEventMemberAdded(ctx context.Context, d
 			*event.Action,
 		)
 	}
-	return dispatch[*github.OrganizationEvent](ctx, deliveryID, eventName, event,
-		g.onOrganizationEvent[OrganizationEventMemberAddedAction],
-		g.onOrganizationEvent[OrganizationEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onOrganizationEvent[OrganizationEventMemberAddedAction]
+	anyHandlers := g.onOrganizationEvent[OrganizationEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.OrganizationEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnOrganizationEventMemberRemoved registers callbacks listening to events of type github.OrganizationEvent and action 'member_removed'.
@@ -295,10 +298,11 @@ func (g *EventHandler) handleOrganizationEventMemberRemoved(ctx context.Context,
 			*event.Action,
 		)
 	}
-	return dispatch[*github.OrganizationEvent](ctx, deliveryID, eventName, event,
-		g.onOrganizationEvent[OrganizationEventMemberRemovedAction],
-		g.onOrganizationEvent[OrganizationEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onOrganizationEvent[OrganizationEventMemberRemovedAction]
+	anyHandlers := g.onOrganizationEvent[OrganizationEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.OrganizationEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnOrganizationEventMemberInvited registers callbacks listening to events of type github.OrganizationEvent and action 'member_invited'.
@@ -358,10 +362,11 @@ func (g *EventHandler) handleOrganizationEventMemberInvited(ctx context.Context,
 			*event.Action,
 		)
 	}
-	return dispatch[*github.OrganizationEvent](ctx, deliveryID, eventName, event,
-		g.onOrganizationEvent[OrganizationEventMemberInvitedAction],
-		g.onOrganizationEvent[OrganizationEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onOrganizationEvent[OrganizationEventMemberInvitedAction]
+	anyHandlers := g.onOrganizationEvent[OrganizationEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.OrganizationEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnOrganizationEventAny registers callbacks listening to any events of type github.OrganizationEvent
@@ -414,7 +419,10 @@ func (g *EventHandler) handleOrganizationEventAny(ctx context.Context, deliveryI
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.OrganizationEvent](ctx, deliveryID, eventName, event, g.onOrganizationEvent[OrganizationEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onOrganizationEvent[OrganizationEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.OrganizationEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // OrganizationEvent handles github.OrganizationEvent.

--- a/githubevents/events_package.go
+++ b/githubevents/events_package.go
@@ -94,10 +94,11 @@ func (g *EventHandler) handlePackageEventPublished(ctx context.Context, delivery
 			*event.Action,
 		)
 	}
-	return dispatch[*github.PackageEvent](ctx, deliveryID, eventName, event,
-		g.onPackageEvent[PackageEventPublishedAction],
-		g.onPackageEvent[PackageEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onPackageEvent[PackageEventPublishedAction]
+	anyHandlers := g.onPackageEvent[PackageEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PackageEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnPackageEventUpdated registers callbacks listening to events of type github.PackageEvent and action 'updated'.
@@ -157,10 +158,11 @@ func (g *EventHandler) handlePackageEventUpdated(ctx context.Context, deliveryID
 			*event.Action,
 		)
 	}
-	return dispatch[*github.PackageEvent](ctx, deliveryID, eventName, event,
-		g.onPackageEvent[PackageEventUpdatedAction],
-		g.onPackageEvent[PackageEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onPackageEvent[PackageEventUpdatedAction]
+	anyHandlers := g.onPackageEvent[PackageEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PackageEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnPackageEventAny registers callbacks listening to any events of type github.PackageEvent
@@ -213,7 +215,10 @@ func (g *EventHandler) handlePackageEventAny(ctx context.Context, deliveryID str
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.PackageEvent](ctx, deliveryID, eventName, event, g.onPackageEvent[PackageEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onPackageEvent[PackageEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PackageEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // PackageEvent handles github.PackageEvent.

--- a/githubevents/events_page_build.go
+++ b/githubevents/events_page_build.go
@@ -79,7 +79,10 @@ func (g *EventHandler) handlePageBuildEventAny(ctx context.Context, deliveryID s
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.PageBuildEvent](ctx, deliveryID, eventName, event, g.onPageBuildEvent[PageBuildEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onPageBuildEvent[PageBuildEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PageBuildEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // PageBuildEvent handles github.PageBuildEvent.

--- a/githubevents/events_ping.go
+++ b/githubevents/events_ping.go
@@ -79,7 +79,10 @@ func (g *EventHandler) handlePingEventAny(ctx context.Context, deliveryID string
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.PingEvent](ctx, deliveryID, eventName, event, g.onPingEvent[PingEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onPingEvent[PingEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PingEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // PingEvent handles github.PingEvent.

--- a/githubevents/events_project_v2.go
+++ b/githubevents/events_project_v2.go
@@ -106,10 +106,11 @@ func (g *EventHandler) handleProjectEventCreated(ctx context.Context, deliveryID
 			*event.Action,
 		)
 	}
-	return dispatch[*github.ProjectV2Event](ctx, deliveryID, eventName, event,
-		g.onProjectV2Event[ProjectEventCreatedAction],
-		g.onProjectV2Event[ProjectV2EventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onProjectV2Event[ProjectEventCreatedAction]
+	anyHandlers := g.onProjectV2Event[ProjectV2EventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.ProjectV2Event](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnProjectEventEdited registers callbacks listening to events of type github.ProjectV2Event and action 'edited'.
@@ -169,10 +170,11 @@ func (g *EventHandler) handleProjectEventEdited(ctx context.Context, deliveryID 
 			*event.Action,
 		)
 	}
-	return dispatch[*github.ProjectV2Event](ctx, deliveryID, eventName, event,
-		g.onProjectV2Event[ProjectEventEditedAction],
-		g.onProjectV2Event[ProjectV2EventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onProjectV2Event[ProjectEventEditedAction]
+	anyHandlers := g.onProjectV2Event[ProjectV2EventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.ProjectV2Event](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnProjectEventClosed registers callbacks listening to events of type github.ProjectV2Event and action 'closed'.
@@ -232,10 +234,11 @@ func (g *EventHandler) handleProjectEventClosed(ctx context.Context, deliveryID 
 			*event.Action,
 		)
 	}
-	return dispatch[*github.ProjectV2Event](ctx, deliveryID, eventName, event,
-		g.onProjectV2Event[ProjectEventClosedAction],
-		g.onProjectV2Event[ProjectV2EventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onProjectV2Event[ProjectEventClosedAction]
+	anyHandlers := g.onProjectV2Event[ProjectV2EventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.ProjectV2Event](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnProjectEventReopened registers callbacks listening to events of type github.ProjectV2Event and action 'reopened'.
@@ -295,10 +298,11 @@ func (g *EventHandler) handleProjectEventReopened(ctx context.Context, deliveryI
 			*event.Action,
 		)
 	}
-	return dispatch[*github.ProjectV2Event](ctx, deliveryID, eventName, event,
-		g.onProjectV2Event[ProjectEventReopenedAction],
-		g.onProjectV2Event[ProjectV2EventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onProjectV2Event[ProjectEventReopenedAction]
+	anyHandlers := g.onProjectV2Event[ProjectV2EventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.ProjectV2Event](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnProjectEventDeleted registers callbacks listening to events of type github.ProjectV2Event and action 'deleted'.
@@ -358,10 +362,11 @@ func (g *EventHandler) handleProjectEventDeleted(ctx context.Context, deliveryID
 			*event.Action,
 		)
 	}
-	return dispatch[*github.ProjectV2Event](ctx, deliveryID, eventName, event,
-		g.onProjectV2Event[ProjectEventDeletedAction],
-		g.onProjectV2Event[ProjectV2EventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onProjectV2Event[ProjectEventDeletedAction]
+	anyHandlers := g.onProjectV2Event[ProjectV2EventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.ProjectV2Event](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnProjectV2EventAny registers callbacks listening to any events of type github.ProjectV2Event
@@ -414,7 +419,10 @@ func (g *EventHandler) handleProjectV2EventAny(ctx context.Context, deliveryID s
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.ProjectV2Event](ctx, deliveryID, eventName, event, g.onProjectV2Event[ProjectV2EventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onProjectV2Event[ProjectV2EventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.ProjectV2Event](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // ProjectV2Event handles github.ProjectV2Event.

--- a/githubevents/events_project_v2_item.go
+++ b/githubevents/events_project_v2_item.go
@@ -114,10 +114,11 @@ func (g *EventHandler) handleProjectItemEventCreated(ctx context.Context, delive
 			*event.Action,
 		)
 	}
-	return dispatch[*github.ProjectV2ItemEvent](ctx, deliveryID, eventName, event,
-		g.onProjectV2ItemEvent[ProjectItemEventCreatedAction],
-		g.onProjectV2ItemEvent[ProjectV2ItemEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onProjectV2ItemEvent[ProjectItemEventCreatedAction]
+	anyHandlers := g.onProjectV2ItemEvent[ProjectV2ItemEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.ProjectV2ItemEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnProjectItemEventEdited registers callbacks listening to events of type github.ProjectV2ItemEvent and action 'edited'.
@@ -177,10 +178,11 @@ func (g *EventHandler) handleProjectItemEventEdited(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	return dispatch[*github.ProjectV2ItemEvent](ctx, deliveryID, eventName, event,
-		g.onProjectV2ItemEvent[ProjectItemEventEditedAction],
-		g.onProjectV2ItemEvent[ProjectV2ItemEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onProjectV2ItemEvent[ProjectItemEventEditedAction]
+	anyHandlers := g.onProjectV2ItemEvent[ProjectV2ItemEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.ProjectV2ItemEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnProjectItemEventClosed registers callbacks listening to events of type github.ProjectV2ItemEvent and action 'closed'.
@@ -240,10 +242,11 @@ func (g *EventHandler) handleProjectItemEventClosed(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	return dispatch[*github.ProjectV2ItemEvent](ctx, deliveryID, eventName, event,
-		g.onProjectV2ItemEvent[ProjectItemEventClosedAction],
-		g.onProjectV2ItemEvent[ProjectV2ItemEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onProjectV2ItemEvent[ProjectItemEventClosedAction]
+	anyHandlers := g.onProjectV2ItemEvent[ProjectV2ItemEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.ProjectV2ItemEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnProjectItemEventReopened registers callbacks listening to events of type github.ProjectV2ItemEvent and action 'reopened'.
@@ -303,10 +306,11 @@ func (g *EventHandler) handleProjectItemEventReopened(ctx context.Context, deliv
 			*event.Action,
 		)
 	}
-	return dispatch[*github.ProjectV2ItemEvent](ctx, deliveryID, eventName, event,
-		g.onProjectV2ItemEvent[ProjectItemEventReopenedAction],
-		g.onProjectV2ItemEvent[ProjectV2ItemEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onProjectV2ItemEvent[ProjectItemEventReopenedAction]
+	anyHandlers := g.onProjectV2ItemEvent[ProjectV2ItemEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.ProjectV2ItemEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnProjectItemEventDeleted registers callbacks listening to events of type github.ProjectV2ItemEvent and action 'deleted'.
@@ -366,10 +370,11 @@ func (g *EventHandler) handleProjectItemEventDeleted(ctx context.Context, delive
 			*event.Action,
 		)
 	}
-	return dispatch[*github.ProjectV2ItemEvent](ctx, deliveryID, eventName, event,
-		g.onProjectV2ItemEvent[ProjectItemEventDeletedAction],
-		g.onProjectV2ItemEvent[ProjectV2ItemEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onProjectV2ItemEvent[ProjectItemEventDeletedAction]
+	anyHandlers := g.onProjectV2ItemEvent[ProjectV2ItemEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.ProjectV2ItemEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnProjectItemEventConverted registers callbacks listening to events of type github.ProjectV2ItemEvent and action 'converted'.
@@ -429,10 +434,11 @@ func (g *EventHandler) handleProjectItemEventConverted(ctx context.Context, deli
 			*event.Action,
 		)
 	}
-	return dispatch[*github.ProjectV2ItemEvent](ctx, deliveryID, eventName, event,
-		g.onProjectV2ItemEvent[ProjectItemEventConvertedAction],
-		g.onProjectV2ItemEvent[ProjectV2ItemEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onProjectV2ItemEvent[ProjectItemEventConvertedAction]
+	anyHandlers := g.onProjectV2ItemEvent[ProjectV2ItemEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.ProjectV2ItemEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnProjectItemEventRestored registers callbacks listening to events of type github.ProjectV2ItemEvent and action 'restored'.
@@ -492,10 +498,11 @@ func (g *EventHandler) handleProjectItemEventRestored(ctx context.Context, deliv
 			*event.Action,
 		)
 	}
-	return dispatch[*github.ProjectV2ItemEvent](ctx, deliveryID, eventName, event,
-		g.onProjectV2ItemEvent[ProjectItemEventRestoredAction],
-		g.onProjectV2ItemEvent[ProjectV2ItemEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onProjectV2ItemEvent[ProjectItemEventRestoredAction]
+	anyHandlers := g.onProjectV2ItemEvent[ProjectV2ItemEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.ProjectV2ItemEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnProjectV2ItemEventAny registers callbacks listening to any events of type github.ProjectV2ItemEvent
@@ -548,7 +555,10 @@ func (g *EventHandler) handleProjectV2ItemEventAny(ctx context.Context, delivery
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.ProjectV2ItemEvent](ctx, deliveryID, eventName, event, g.onProjectV2ItemEvent[ProjectV2ItemEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onProjectV2ItemEvent[ProjectV2ItemEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.ProjectV2ItemEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // ProjectV2ItemEvent handles github.ProjectV2ItemEvent.

--- a/githubevents/events_public.go
+++ b/githubevents/events_public.go
@@ -79,7 +79,10 @@ func (g *EventHandler) handlePublicEventAny(ctx context.Context, deliveryID stri
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.PublicEvent](ctx, deliveryID, eventName, event, g.onPublicEvent[PublicEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onPublicEvent[PublicEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PublicEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // PublicEvent handles github.PublicEvent.

--- a/githubevents/events_pull_request.go
+++ b/githubevents/events_pull_request.go
@@ -154,10 +154,11 @@ func (g *EventHandler) handlePullRequestEventAssigned(ctx context.Context, deliv
 			*event.Action,
 		)
 	}
-	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
-		g.onPullRequestEvent[PullRequestEventAssignedAction],
-		g.onPullRequestEvent[PullRequestEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onPullRequestEvent[PullRequestEventAssignedAction]
+	anyHandlers := g.onPullRequestEvent[PullRequestEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnPullRequestEventAutoMergeDisabled registers callbacks listening to events of type github.PullRequestEvent and action 'auto_merge_disabled'.
@@ -217,10 +218,11 @@ func (g *EventHandler) handlePullRequestEventAutoMergeDisabled(ctx context.Conte
 			*event.Action,
 		)
 	}
-	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
-		g.onPullRequestEvent[PullRequestEventAutoMergeDisabledAction],
-		g.onPullRequestEvent[PullRequestEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onPullRequestEvent[PullRequestEventAutoMergeDisabledAction]
+	anyHandlers := g.onPullRequestEvent[PullRequestEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnPullRequestEventAutoMergeEnabled registers callbacks listening to events of type github.PullRequestEvent and action 'auto_merge_enabled'.
@@ -280,10 +282,11 @@ func (g *EventHandler) handlePullRequestEventAutoMergeEnabled(ctx context.Contex
 			*event.Action,
 		)
 	}
-	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
-		g.onPullRequestEvent[PullRequestEventAutoMergeEnabledAction],
-		g.onPullRequestEvent[PullRequestEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onPullRequestEvent[PullRequestEventAutoMergeEnabledAction]
+	anyHandlers := g.onPullRequestEvent[PullRequestEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnPullRequestEventClosed registers callbacks listening to events of type github.PullRequestEvent and action 'closed'.
@@ -343,10 +346,11 @@ func (g *EventHandler) handlePullRequestEventClosed(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
-		g.onPullRequestEvent[PullRequestEventClosedAction],
-		g.onPullRequestEvent[PullRequestEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onPullRequestEvent[PullRequestEventClosedAction]
+	anyHandlers := g.onPullRequestEvent[PullRequestEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnPullRequestEventConvertedToDraft registers callbacks listening to events of type github.PullRequestEvent and action 'converted_to_draft'.
@@ -406,10 +410,11 @@ func (g *EventHandler) handlePullRequestEventConvertedToDraft(ctx context.Contex
 			*event.Action,
 		)
 	}
-	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
-		g.onPullRequestEvent[PullRequestEventConvertedToDraftAction],
-		g.onPullRequestEvent[PullRequestEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onPullRequestEvent[PullRequestEventConvertedToDraftAction]
+	anyHandlers := g.onPullRequestEvent[PullRequestEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnPullRequestEventEdited registers callbacks listening to events of type github.PullRequestEvent and action 'edited'.
@@ -469,10 +474,11 @@ func (g *EventHandler) handlePullRequestEventEdited(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
-		g.onPullRequestEvent[PullRequestEventEditedAction],
-		g.onPullRequestEvent[PullRequestEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onPullRequestEvent[PullRequestEventEditedAction]
+	anyHandlers := g.onPullRequestEvent[PullRequestEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnPullRequestEventLabeled registers callbacks listening to events of type github.PullRequestEvent and action 'labeled'.
@@ -532,10 +538,11 @@ func (g *EventHandler) handlePullRequestEventLabeled(ctx context.Context, delive
 			*event.Action,
 		)
 	}
-	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
-		g.onPullRequestEvent[PullRequestEventLabeledAction],
-		g.onPullRequestEvent[PullRequestEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onPullRequestEvent[PullRequestEventLabeledAction]
+	anyHandlers := g.onPullRequestEvent[PullRequestEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnPullRequestEventLocked registers callbacks listening to events of type github.PullRequestEvent and action 'locked'.
@@ -595,10 +602,11 @@ func (g *EventHandler) handlePullRequestEventLocked(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
-		g.onPullRequestEvent[PullRequestEventLockedAction],
-		g.onPullRequestEvent[PullRequestEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onPullRequestEvent[PullRequestEventLockedAction]
+	anyHandlers := g.onPullRequestEvent[PullRequestEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnPullRequestEventOpened registers callbacks listening to events of type github.PullRequestEvent and action 'opened'.
@@ -658,10 +666,11 @@ func (g *EventHandler) handlePullRequestEventOpened(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
-		g.onPullRequestEvent[PullRequestEventOpenedAction],
-		g.onPullRequestEvent[PullRequestEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onPullRequestEvent[PullRequestEventOpenedAction]
+	anyHandlers := g.onPullRequestEvent[PullRequestEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnPullRequestEventReadyForReview registers callbacks listening to events of type github.PullRequestEvent and action 'ready_for_review'.
@@ -721,10 +730,11 @@ func (g *EventHandler) handlePullRequestEventReadyForReview(ctx context.Context,
 			*event.Action,
 		)
 	}
-	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
-		g.onPullRequestEvent[PullRequestEventReadyForReviewAction],
-		g.onPullRequestEvent[PullRequestEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onPullRequestEvent[PullRequestEventReadyForReviewAction]
+	anyHandlers := g.onPullRequestEvent[PullRequestEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnPullRequestEventReopened registers callbacks listening to events of type github.PullRequestEvent and action 'reopened'.
@@ -784,10 +794,11 @@ func (g *EventHandler) handlePullRequestEventReopened(ctx context.Context, deliv
 			*event.Action,
 		)
 	}
-	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
-		g.onPullRequestEvent[PullRequestEventReopenedAction],
-		g.onPullRequestEvent[PullRequestEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onPullRequestEvent[PullRequestEventReopenedAction]
+	anyHandlers := g.onPullRequestEvent[PullRequestEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnPullRequestEventReviewRequestRemoved registers callbacks listening to events of type github.PullRequestEvent and action 'review_request_removed'.
@@ -847,10 +858,11 @@ func (g *EventHandler) handlePullRequestEventReviewRequestRemoved(ctx context.Co
 			*event.Action,
 		)
 	}
-	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
-		g.onPullRequestEvent[PullRequestEventReviewRequestRemovedAction],
-		g.onPullRequestEvent[PullRequestEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onPullRequestEvent[PullRequestEventReviewRequestRemovedAction]
+	anyHandlers := g.onPullRequestEvent[PullRequestEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnPullRequestEventReviewRequested registers callbacks listening to events of type github.PullRequestEvent and action 'review_requested'.
@@ -910,10 +922,11 @@ func (g *EventHandler) handlePullRequestEventReviewRequested(ctx context.Context
 			*event.Action,
 		)
 	}
-	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
-		g.onPullRequestEvent[PullRequestEventReviewRequestedAction],
-		g.onPullRequestEvent[PullRequestEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onPullRequestEvent[PullRequestEventReviewRequestedAction]
+	anyHandlers := g.onPullRequestEvent[PullRequestEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnPullRequestEventSynchronize registers callbacks listening to events of type github.PullRequestEvent and action 'synchronize'.
@@ -973,10 +986,11 @@ func (g *EventHandler) handlePullRequestEventSynchronize(ctx context.Context, de
 			*event.Action,
 		)
 	}
-	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
-		g.onPullRequestEvent[PullRequestEventSynchronizeAction],
-		g.onPullRequestEvent[PullRequestEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onPullRequestEvent[PullRequestEventSynchronizeAction]
+	anyHandlers := g.onPullRequestEvent[PullRequestEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnPullRequestEventUnassigned registers callbacks listening to events of type github.PullRequestEvent and action 'unassigned'.
@@ -1036,10 +1050,11 @@ func (g *EventHandler) handlePullRequestEventUnassigned(ctx context.Context, del
 			*event.Action,
 		)
 	}
-	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
-		g.onPullRequestEvent[PullRequestEventUnassignedAction],
-		g.onPullRequestEvent[PullRequestEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onPullRequestEvent[PullRequestEventUnassignedAction]
+	anyHandlers := g.onPullRequestEvent[PullRequestEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnPullRequestEventUnlabeled registers callbacks listening to events of type github.PullRequestEvent and action 'unlabeled'.
@@ -1099,10 +1114,11 @@ func (g *EventHandler) handlePullRequestEventUnlabeled(ctx context.Context, deli
 			*event.Action,
 		)
 	}
-	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
-		g.onPullRequestEvent[PullRequestEventUnlabeledAction],
-		g.onPullRequestEvent[PullRequestEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onPullRequestEvent[PullRequestEventUnlabeledAction]
+	anyHandlers := g.onPullRequestEvent[PullRequestEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnPullRequestEventUnlocked registers callbacks listening to events of type github.PullRequestEvent and action 'unlocked'.
@@ -1162,10 +1178,11 @@ func (g *EventHandler) handlePullRequestEventUnlocked(ctx context.Context, deliv
 			*event.Action,
 		)
 	}
-	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event,
-		g.onPullRequestEvent[PullRequestEventUnlockedAction],
-		g.onPullRequestEvent[PullRequestEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onPullRequestEvent[PullRequestEventUnlockedAction]
+	anyHandlers := g.onPullRequestEvent[PullRequestEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnPullRequestEventAny registers callbacks listening to any events of type github.PullRequestEvent
@@ -1218,7 +1235,10 @@ func (g *EventHandler) handlePullRequestEventAny(ctx context.Context, deliveryID
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event, g.onPullRequestEvent[PullRequestEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onPullRequestEvent[PullRequestEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PullRequestEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // PullRequestEvent handles github.PullRequestEvent.

--- a/githubevents/events_pull_request_review.go
+++ b/githubevents/events_pull_request_review.go
@@ -98,10 +98,11 @@ func (g *EventHandler) handlePullRequestReviewEventSubmitted(ctx context.Context
 			*event.Action,
 		)
 	}
-	return dispatch[*github.PullRequestReviewEvent](ctx, deliveryID, eventName, event,
-		g.onPullRequestReviewEvent[PullRequestReviewEventSubmittedAction],
-		g.onPullRequestReviewEvent[PullRequestReviewEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onPullRequestReviewEvent[PullRequestReviewEventSubmittedAction]
+	anyHandlers := g.onPullRequestReviewEvent[PullRequestReviewEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PullRequestReviewEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnPullRequestReviewEventEdited registers callbacks listening to events of type github.PullRequestReviewEvent and action 'edited'.
@@ -161,10 +162,11 @@ func (g *EventHandler) handlePullRequestReviewEventEdited(ctx context.Context, d
 			*event.Action,
 		)
 	}
-	return dispatch[*github.PullRequestReviewEvent](ctx, deliveryID, eventName, event,
-		g.onPullRequestReviewEvent[PullRequestReviewEventEditedAction],
-		g.onPullRequestReviewEvent[PullRequestReviewEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onPullRequestReviewEvent[PullRequestReviewEventEditedAction]
+	anyHandlers := g.onPullRequestReviewEvent[PullRequestReviewEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PullRequestReviewEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnPullRequestReviewEventDismissed registers callbacks listening to events of type github.PullRequestReviewEvent and action 'dismissed'.
@@ -224,10 +226,11 @@ func (g *EventHandler) handlePullRequestReviewEventDismissed(ctx context.Context
 			*event.Action,
 		)
 	}
-	return dispatch[*github.PullRequestReviewEvent](ctx, deliveryID, eventName, event,
-		g.onPullRequestReviewEvent[PullRequestReviewEventDismissedAction],
-		g.onPullRequestReviewEvent[PullRequestReviewEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onPullRequestReviewEvent[PullRequestReviewEventDismissedAction]
+	anyHandlers := g.onPullRequestReviewEvent[PullRequestReviewEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PullRequestReviewEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnPullRequestReviewEventAny registers callbacks listening to any events of type github.PullRequestReviewEvent
@@ -280,7 +283,10 @@ func (g *EventHandler) handlePullRequestReviewEventAny(ctx context.Context, deli
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.PullRequestReviewEvent](ctx, deliveryID, eventName, event, g.onPullRequestReviewEvent[PullRequestReviewEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onPullRequestReviewEvent[PullRequestReviewEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PullRequestReviewEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // PullRequestReviewEvent handles github.PullRequestReviewEvent.

--- a/githubevents/events_pull_request_review_comment.go
+++ b/githubevents/events_pull_request_review_comment.go
@@ -98,10 +98,11 @@ func (g *EventHandler) handlePullRequestReviewCommentEventCreated(ctx context.Co
 			*event.Action,
 		)
 	}
-	return dispatch[*github.PullRequestReviewCommentEvent](ctx, deliveryID, eventName, event,
-		g.onPullRequestReviewCommentEvent[PullRequestReviewCommentEventCreatedAction],
-		g.onPullRequestReviewCommentEvent[PullRequestReviewCommentEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onPullRequestReviewCommentEvent[PullRequestReviewCommentEventCreatedAction]
+	anyHandlers := g.onPullRequestReviewCommentEvent[PullRequestReviewCommentEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PullRequestReviewCommentEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnPullRequestReviewCommentEventEdited registers callbacks listening to events of type github.PullRequestReviewCommentEvent and action 'edited'.
@@ -161,10 +162,11 @@ func (g *EventHandler) handlePullRequestReviewCommentEventEdited(ctx context.Con
 			*event.Action,
 		)
 	}
-	return dispatch[*github.PullRequestReviewCommentEvent](ctx, deliveryID, eventName, event,
-		g.onPullRequestReviewCommentEvent[PullRequestReviewCommentEventEditedAction],
-		g.onPullRequestReviewCommentEvent[PullRequestReviewCommentEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onPullRequestReviewCommentEvent[PullRequestReviewCommentEventEditedAction]
+	anyHandlers := g.onPullRequestReviewCommentEvent[PullRequestReviewCommentEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PullRequestReviewCommentEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnPullRequestReviewCommentEventDeleted registers callbacks listening to events of type github.PullRequestReviewCommentEvent and action 'deleted'.
@@ -224,10 +226,11 @@ func (g *EventHandler) handlePullRequestReviewCommentEventDeleted(ctx context.Co
 			*event.Action,
 		)
 	}
-	return dispatch[*github.PullRequestReviewCommentEvent](ctx, deliveryID, eventName, event,
-		g.onPullRequestReviewCommentEvent[PullRequestReviewCommentEventDeletedAction],
-		g.onPullRequestReviewCommentEvent[PullRequestReviewCommentEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onPullRequestReviewCommentEvent[PullRequestReviewCommentEventDeletedAction]
+	anyHandlers := g.onPullRequestReviewCommentEvent[PullRequestReviewCommentEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PullRequestReviewCommentEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnPullRequestReviewCommentEventAny registers callbacks listening to any events of type github.PullRequestReviewCommentEvent
@@ -280,7 +283,10 @@ func (g *EventHandler) handlePullRequestReviewCommentEventAny(ctx context.Contex
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.PullRequestReviewCommentEvent](ctx, deliveryID, eventName, event, g.onPullRequestReviewCommentEvent[PullRequestReviewCommentEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onPullRequestReviewCommentEvent[PullRequestReviewCommentEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PullRequestReviewCommentEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // PullRequestReviewCommentEvent handles github.PullRequestReviewCommentEvent.

--- a/githubevents/events_push.go
+++ b/githubevents/events_push.go
@@ -79,7 +79,10 @@ func (g *EventHandler) handlePushEventAny(ctx context.Context, deliveryID string
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.PushEvent](ctx, deliveryID, eventName, event, g.onPushEvent[PushEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onPushEvent[PushEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.PushEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // PushEvent handles github.PushEvent.

--- a/githubevents/events_release.go
+++ b/githubevents/events_release.go
@@ -114,10 +114,11 @@ func (g *EventHandler) handleReleaseEventPublished(ctx context.Context, delivery
 			*event.Action,
 		)
 	}
-	return dispatch[*github.ReleaseEvent](ctx, deliveryID, eventName, event,
-		g.onReleaseEvent[ReleaseEventPublishedAction],
-		g.onReleaseEvent[ReleaseEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onReleaseEvent[ReleaseEventPublishedAction]
+	anyHandlers := g.onReleaseEvent[ReleaseEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.ReleaseEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnReleaseEventUnpublished registers callbacks listening to events of type github.ReleaseEvent and action 'unpublished'.
@@ -177,10 +178,11 @@ func (g *EventHandler) handleReleaseEventUnpublished(ctx context.Context, delive
 			*event.Action,
 		)
 	}
-	return dispatch[*github.ReleaseEvent](ctx, deliveryID, eventName, event,
-		g.onReleaseEvent[ReleaseEventUnpublishedAction],
-		g.onReleaseEvent[ReleaseEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onReleaseEvent[ReleaseEventUnpublishedAction]
+	anyHandlers := g.onReleaseEvent[ReleaseEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.ReleaseEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnReleaseEventCreated registers callbacks listening to events of type github.ReleaseEvent and action 'created'.
@@ -240,10 +242,11 @@ func (g *EventHandler) handleReleaseEventCreated(ctx context.Context, deliveryID
 			*event.Action,
 		)
 	}
-	return dispatch[*github.ReleaseEvent](ctx, deliveryID, eventName, event,
-		g.onReleaseEvent[ReleaseEventCreatedAction],
-		g.onReleaseEvent[ReleaseEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onReleaseEvent[ReleaseEventCreatedAction]
+	anyHandlers := g.onReleaseEvent[ReleaseEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.ReleaseEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnReleaseEventEdited registers callbacks listening to events of type github.ReleaseEvent and action 'edited'.
@@ -303,10 +306,11 @@ func (g *EventHandler) handleReleaseEventEdited(ctx context.Context, deliveryID 
 			*event.Action,
 		)
 	}
-	return dispatch[*github.ReleaseEvent](ctx, deliveryID, eventName, event,
-		g.onReleaseEvent[ReleaseEventEditedAction],
-		g.onReleaseEvent[ReleaseEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onReleaseEvent[ReleaseEventEditedAction]
+	anyHandlers := g.onReleaseEvent[ReleaseEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.ReleaseEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnReleaseEventDeleted registers callbacks listening to events of type github.ReleaseEvent and action 'deleted'.
@@ -366,10 +370,11 @@ func (g *EventHandler) handleReleaseEventDeleted(ctx context.Context, deliveryID
 			*event.Action,
 		)
 	}
-	return dispatch[*github.ReleaseEvent](ctx, deliveryID, eventName, event,
-		g.onReleaseEvent[ReleaseEventDeletedAction],
-		g.onReleaseEvent[ReleaseEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onReleaseEvent[ReleaseEventDeletedAction]
+	anyHandlers := g.onReleaseEvent[ReleaseEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.ReleaseEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnReleaseEventPreReleased registers callbacks listening to events of type github.ReleaseEvent and action 'prereleased'.
@@ -429,10 +434,11 @@ func (g *EventHandler) handleReleaseEventPreReleased(ctx context.Context, delive
 			*event.Action,
 		)
 	}
-	return dispatch[*github.ReleaseEvent](ctx, deliveryID, eventName, event,
-		g.onReleaseEvent[ReleaseEventPreReleasedAction],
-		g.onReleaseEvent[ReleaseEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onReleaseEvent[ReleaseEventPreReleasedAction]
+	anyHandlers := g.onReleaseEvent[ReleaseEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.ReleaseEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnReleaseEventReleased registers callbacks listening to events of type github.ReleaseEvent and action 'released'.
@@ -492,10 +498,11 @@ func (g *EventHandler) handleReleaseEventReleased(ctx context.Context, deliveryI
 			*event.Action,
 		)
 	}
-	return dispatch[*github.ReleaseEvent](ctx, deliveryID, eventName, event,
-		g.onReleaseEvent[ReleaseEventReleasedAction],
-		g.onReleaseEvent[ReleaseEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onReleaseEvent[ReleaseEventReleasedAction]
+	anyHandlers := g.onReleaseEvent[ReleaseEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.ReleaseEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnReleaseEventAny registers callbacks listening to any events of type github.ReleaseEvent
@@ -548,7 +555,10 @@ func (g *EventHandler) handleReleaseEventAny(ctx context.Context, deliveryID str
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.ReleaseEvent](ctx, deliveryID, eventName, event, g.onReleaseEvent[ReleaseEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onReleaseEvent[ReleaseEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.ReleaseEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // ReleaseEvent handles github.ReleaseEvent.

--- a/githubevents/events_repository.go
+++ b/githubevents/events_repository.go
@@ -122,10 +122,11 @@ func (g *EventHandler) handleRepositoryEventCreated(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event,
-		g.onRepositoryEvent[RepositoryEventCreatedAction],
-		g.onRepositoryEvent[RepositoryEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onRepositoryEvent[RepositoryEventCreatedAction]
+	anyHandlers := g.onRepositoryEvent[RepositoryEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnRepositoryEventDeleted registers callbacks listening to events of type github.RepositoryEvent and action 'deleted'.
@@ -185,10 +186,11 @@ func (g *EventHandler) handleRepositoryEventDeleted(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event,
-		g.onRepositoryEvent[RepositoryEventDeletedAction],
-		g.onRepositoryEvent[RepositoryEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onRepositoryEvent[RepositoryEventDeletedAction]
+	anyHandlers := g.onRepositoryEvent[RepositoryEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnRepositoryEventArchived registers callbacks listening to events of type github.RepositoryEvent and action 'archived'.
@@ -248,10 +250,11 @@ func (g *EventHandler) handleRepositoryEventArchived(ctx context.Context, delive
 			*event.Action,
 		)
 	}
-	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event,
-		g.onRepositoryEvent[RepositoryEventArchivedAction],
-		g.onRepositoryEvent[RepositoryEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onRepositoryEvent[RepositoryEventArchivedAction]
+	anyHandlers := g.onRepositoryEvent[RepositoryEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnRepositoryEventUnarchived registers callbacks listening to events of type github.RepositoryEvent and action 'unarchived'.
@@ -311,10 +314,11 @@ func (g *EventHandler) handleRepositoryEventUnarchived(ctx context.Context, deli
 			*event.Action,
 		)
 	}
-	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event,
-		g.onRepositoryEvent[RepositoryEventUnarchivedAction],
-		g.onRepositoryEvent[RepositoryEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onRepositoryEvent[RepositoryEventUnarchivedAction]
+	anyHandlers := g.onRepositoryEvent[RepositoryEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnRepositoryEventEdited registers callbacks listening to events of type github.RepositoryEvent and action 'edited'.
@@ -374,10 +378,11 @@ func (g *EventHandler) handleRepositoryEventEdited(ctx context.Context, delivery
 			*event.Action,
 		)
 	}
-	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event,
-		g.onRepositoryEvent[RepositoryEventEditedAction],
-		g.onRepositoryEvent[RepositoryEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onRepositoryEvent[RepositoryEventEditedAction]
+	anyHandlers := g.onRepositoryEvent[RepositoryEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnRepositoryEventRenamed registers callbacks listening to events of type github.RepositoryEvent and action 'renamed'.
@@ -437,10 +442,11 @@ func (g *EventHandler) handleRepositoryEventRenamed(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event,
-		g.onRepositoryEvent[RepositoryEventRenamedAction],
-		g.onRepositoryEvent[RepositoryEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onRepositoryEvent[RepositoryEventRenamedAction]
+	anyHandlers := g.onRepositoryEvent[RepositoryEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnRepositoryEventTransferred registers callbacks listening to events of type github.RepositoryEvent and action 'transferred'.
@@ -500,10 +506,11 @@ func (g *EventHandler) handleRepositoryEventTransferred(ctx context.Context, del
 			*event.Action,
 		)
 	}
-	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event,
-		g.onRepositoryEvent[RepositoryEventTransferredAction],
-		g.onRepositoryEvent[RepositoryEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onRepositoryEvent[RepositoryEventTransferredAction]
+	anyHandlers := g.onRepositoryEvent[RepositoryEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnRepositoryEventPublicized registers callbacks listening to events of type github.RepositoryEvent and action 'publicized'.
@@ -563,10 +570,11 @@ func (g *EventHandler) handleRepositoryEventPublicized(ctx context.Context, deli
 			*event.Action,
 		)
 	}
-	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event,
-		g.onRepositoryEvent[RepositoryEventPublicizedAction],
-		g.onRepositoryEvent[RepositoryEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onRepositoryEvent[RepositoryEventPublicizedAction]
+	anyHandlers := g.onRepositoryEvent[RepositoryEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnRepositoryEventPrivatized registers callbacks listening to events of type github.RepositoryEvent and action 'privatized'.
@@ -626,10 +634,11 @@ func (g *EventHandler) handleRepositoryEventPrivatized(ctx context.Context, deli
 			*event.Action,
 		)
 	}
-	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event,
-		g.onRepositoryEvent[RepositoryEventPrivatizedAction],
-		g.onRepositoryEvent[RepositoryEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onRepositoryEvent[RepositoryEventPrivatizedAction]
+	anyHandlers := g.onRepositoryEvent[RepositoryEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnRepositoryEventAny registers callbacks listening to any events of type github.RepositoryEvent
@@ -682,7 +691,10 @@ func (g *EventHandler) handleRepositoryEventAny(ctx context.Context, deliveryID 
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event, g.onRepositoryEvent[RepositoryEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onRepositoryEvent[RepositoryEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.RepositoryEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // RepositoryEvent handles github.RepositoryEvent.

--- a/githubevents/events_repository_dispatch.go
+++ b/githubevents/events_repository_dispatch.go
@@ -79,7 +79,10 @@ func (g *EventHandler) handleRepositoryDispatchEventAny(ctx context.Context, del
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.RepositoryDispatchEvent](ctx, deliveryID, eventName, event, g.onRepositoryDispatchEvent[RepositoryDispatchEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onRepositoryDispatchEvent[RepositoryDispatchEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.RepositoryDispatchEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // RepositoryDispatchEvent handles github.RepositoryDispatchEvent.

--- a/githubevents/events_repository_ruleset.go
+++ b/githubevents/events_repository_ruleset.go
@@ -98,10 +98,11 @@ func (g *EventHandler) handleRepositoryRulesetEventCreated(ctx context.Context, 
 			*event.Action,
 		)
 	}
-	return dispatch[*github.RepositoryRulesetEvent](ctx, deliveryID, eventName, event,
-		g.onRepositoryRulesetEvent[RepositoryRulesetEventCreatedAction],
-		g.onRepositoryRulesetEvent[RepositoryRulesetEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onRepositoryRulesetEvent[RepositoryRulesetEventCreatedAction]
+	anyHandlers := g.onRepositoryRulesetEvent[RepositoryRulesetEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.RepositoryRulesetEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnRepositoryRulesetEventDeleted registers callbacks listening to events of type github.RepositoryRulesetEvent and action 'deleted'.
@@ -161,10 +162,11 @@ func (g *EventHandler) handleRepositoryRulesetEventDeleted(ctx context.Context, 
 			*event.Action,
 		)
 	}
-	return dispatch[*github.RepositoryRulesetEvent](ctx, deliveryID, eventName, event,
-		g.onRepositoryRulesetEvent[RepositoryRulesetEventDeletedAction],
-		g.onRepositoryRulesetEvent[RepositoryRulesetEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onRepositoryRulesetEvent[RepositoryRulesetEventDeletedAction]
+	anyHandlers := g.onRepositoryRulesetEvent[RepositoryRulesetEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.RepositoryRulesetEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnRepositoryRulesetEventEdited registers callbacks listening to events of type github.RepositoryRulesetEvent and action 'edited'.
@@ -224,10 +226,11 @@ func (g *EventHandler) handleRepositoryRulesetEventEdited(ctx context.Context, d
 			*event.Action,
 		)
 	}
-	return dispatch[*github.RepositoryRulesetEvent](ctx, deliveryID, eventName, event,
-		g.onRepositoryRulesetEvent[RepositoryRulesetEventEditedAction],
-		g.onRepositoryRulesetEvent[RepositoryRulesetEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onRepositoryRulesetEvent[RepositoryRulesetEventEditedAction]
+	anyHandlers := g.onRepositoryRulesetEvent[RepositoryRulesetEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.RepositoryRulesetEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnRepositoryRulesetEventAny registers callbacks listening to any events of type github.RepositoryRulesetEvent
@@ -280,7 +283,10 @@ func (g *EventHandler) handleRepositoryRulesetEventAny(ctx context.Context, deli
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.RepositoryRulesetEvent](ctx, deliveryID, eventName, event, g.onRepositoryRulesetEvent[RepositoryRulesetEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onRepositoryRulesetEvent[RepositoryRulesetEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.RepositoryRulesetEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // RepositoryRulesetEvent handles github.RepositoryRulesetEvent.

--- a/githubevents/events_repository_vulnerability_alert.go
+++ b/githubevents/events_repository_vulnerability_alert.go
@@ -98,10 +98,11 @@ func (g *EventHandler) handleRepositoryVulnerabilityAlertEventCreate(ctx context
 			*event.Action,
 		)
 	}
-	return dispatch[*github.RepositoryVulnerabilityAlertEvent](ctx, deliveryID, eventName, event,
-		g.onRepositoryVulnerabilityAlertEvent[RepositoryVulnerabilityAlertEventCreateAction],
-		g.onRepositoryVulnerabilityAlertEvent[RepositoryVulnerabilityAlertEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onRepositoryVulnerabilityAlertEvent[RepositoryVulnerabilityAlertEventCreateAction]
+	anyHandlers := g.onRepositoryVulnerabilityAlertEvent[RepositoryVulnerabilityAlertEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.RepositoryVulnerabilityAlertEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnRepositoryVulnerabilityAlertEventDismiss registers callbacks listening to events of type github.RepositoryVulnerabilityAlertEvent and action 'dismiss'.
@@ -161,10 +162,11 @@ func (g *EventHandler) handleRepositoryVulnerabilityAlertEventDismiss(ctx contex
 			*event.Action,
 		)
 	}
-	return dispatch[*github.RepositoryVulnerabilityAlertEvent](ctx, deliveryID, eventName, event,
-		g.onRepositoryVulnerabilityAlertEvent[RepositoryVulnerabilityAlertEventDismissAction],
-		g.onRepositoryVulnerabilityAlertEvent[RepositoryVulnerabilityAlertEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onRepositoryVulnerabilityAlertEvent[RepositoryVulnerabilityAlertEventDismissAction]
+	anyHandlers := g.onRepositoryVulnerabilityAlertEvent[RepositoryVulnerabilityAlertEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.RepositoryVulnerabilityAlertEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnRepositoryVulnerabilityAlertEventResolve registers callbacks listening to events of type github.RepositoryVulnerabilityAlertEvent and action 'resolve'.
@@ -224,10 +226,11 @@ func (g *EventHandler) handleRepositoryVulnerabilityAlertEventResolve(ctx contex
 			*event.Action,
 		)
 	}
-	return dispatch[*github.RepositoryVulnerabilityAlertEvent](ctx, deliveryID, eventName, event,
-		g.onRepositoryVulnerabilityAlertEvent[RepositoryVulnerabilityAlertEventResolveAction],
-		g.onRepositoryVulnerabilityAlertEvent[RepositoryVulnerabilityAlertEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onRepositoryVulnerabilityAlertEvent[RepositoryVulnerabilityAlertEventResolveAction]
+	anyHandlers := g.onRepositoryVulnerabilityAlertEvent[RepositoryVulnerabilityAlertEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.RepositoryVulnerabilityAlertEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnRepositoryVulnerabilityAlertEventAny registers callbacks listening to any events of type github.RepositoryVulnerabilityAlertEvent
@@ -280,7 +283,10 @@ func (g *EventHandler) handleRepositoryVulnerabilityAlertEventAny(ctx context.Co
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.RepositoryVulnerabilityAlertEvent](ctx, deliveryID, eventName, event, g.onRepositoryVulnerabilityAlertEvent[RepositoryVulnerabilityAlertEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onRepositoryVulnerabilityAlertEvent[RepositoryVulnerabilityAlertEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.RepositoryVulnerabilityAlertEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // RepositoryVulnerabilityAlertEvent handles github.RepositoryVulnerabilityAlertEvent.

--- a/githubevents/events_star.go
+++ b/githubevents/events_star.go
@@ -94,10 +94,11 @@ func (g *EventHandler) handleStarEventCreated(ctx context.Context, deliveryID st
 			*event.Action,
 		)
 	}
-	return dispatch[*github.StarEvent](ctx, deliveryID, eventName, event,
-		g.onStarEvent[StarEventCreatedAction],
-		g.onStarEvent[StarEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onStarEvent[StarEventCreatedAction]
+	anyHandlers := g.onStarEvent[StarEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.StarEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnStarEventDeleted registers callbacks listening to events of type github.StarEvent and action 'deleted'.
@@ -157,10 +158,11 @@ func (g *EventHandler) handleStarEventDeleted(ctx context.Context, deliveryID st
 			*event.Action,
 		)
 	}
-	return dispatch[*github.StarEvent](ctx, deliveryID, eventName, event,
-		g.onStarEvent[StarEventDeletedAction],
-		g.onStarEvent[StarEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onStarEvent[StarEventDeletedAction]
+	anyHandlers := g.onStarEvent[StarEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.StarEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnStarEventAny registers callbacks listening to any events of type github.StarEvent
@@ -213,7 +215,10 @@ func (g *EventHandler) handleStarEventAny(ctx context.Context, deliveryID string
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.StarEvent](ctx, deliveryID, eventName, event, g.onStarEvent[StarEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onStarEvent[StarEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.StarEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // StarEvent handles github.StarEvent.

--- a/githubevents/events_status.go
+++ b/githubevents/events_status.go
@@ -79,7 +79,10 @@ func (g *EventHandler) handleStatusEventAny(ctx context.Context, deliveryID stri
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.StatusEvent](ctx, deliveryID, eventName, event, g.onStatusEvent[StatusEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onStatusEvent[StatusEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.StatusEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // StatusEvent handles github.StatusEvent.

--- a/githubevents/events_team.go
+++ b/githubevents/events_team.go
@@ -106,10 +106,11 @@ func (g *EventHandler) handleTeamEventCreated(ctx context.Context, deliveryID st
 			*event.Action,
 		)
 	}
-	return dispatch[*github.TeamEvent](ctx, deliveryID, eventName, event,
-		g.onTeamEvent[TeamEventCreatedAction],
-		g.onTeamEvent[TeamEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onTeamEvent[TeamEventCreatedAction]
+	anyHandlers := g.onTeamEvent[TeamEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.TeamEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnTeamEventDeleted registers callbacks listening to events of type github.TeamEvent and action 'deleted'.
@@ -169,10 +170,11 @@ func (g *EventHandler) handleTeamEventDeleted(ctx context.Context, deliveryID st
 			*event.Action,
 		)
 	}
-	return dispatch[*github.TeamEvent](ctx, deliveryID, eventName, event,
-		g.onTeamEvent[TeamEventDeletedAction],
-		g.onTeamEvent[TeamEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onTeamEvent[TeamEventDeletedAction]
+	anyHandlers := g.onTeamEvent[TeamEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.TeamEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnTeamEventEdited registers callbacks listening to events of type github.TeamEvent and action 'edited'.
@@ -232,10 +234,11 @@ func (g *EventHandler) handleTeamEventEdited(ctx context.Context, deliveryID str
 			*event.Action,
 		)
 	}
-	return dispatch[*github.TeamEvent](ctx, deliveryID, eventName, event,
-		g.onTeamEvent[TeamEventEditedAction],
-		g.onTeamEvent[TeamEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onTeamEvent[TeamEventEditedAction]
+	anyHandlers := g.onTeamEvent[TeamEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.TeamEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnTeamEventAddedToRepository registers callbacks listening to events of type github.TeamEvent and action 'added_to_repository'.
@@ -295,10 +298,11 @@ func (g *EventHandler) handleTeamEventAddedToRepository(ctx context.Context, del
 			*event.Action,
 		)
 	}
-	return dispatch[*github.TeamEvent](ctx, deliveryID, eventName, event,
-		g.onTeamEvent[TeamEventAddedToRepositoryAction],
-		g.onTeamEvent[TeamEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onTeamEvent[TeamEventAddedToRepositoryAction]
+	anyHandlers := g.onTeamEvent[TeamEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.TeamEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnTeamEventRemovedFromRepository registers callbacks listening to events of type github.TeamEvent and action 'removed_from_repository'.
@@ -358,10 +362,11 @@ func (g *EventHandler) handleTeamEventRemovedFromRepository(ctx context.Context,
 			*event.Action,
 		)
 	}
-	return dispatch[*github.TeamEvent](ctx, deliveryID, eventName, event,
-		g.onTeamEvent[TeamEventRemovedFromRepositoryAction],
-		g.onTeamEvent[TeamEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onTeamEvent[TeamEventRemovedFromRepositoryAction]
+	anyHandlers := g.onTeamEvent[TeamEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.TeamEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnTeamEventAny registers callbacks listening to any events of type github.TeamEvent
@@ -414,7 +419,10 @@ func (g *EventHandler) handleTeamEventAny(ctx context.Context, deliveryID string
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.TeamEvent](ctx, deliveryID, eventName, event, g.onTeamEvent[TeamEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onTeamEvent[TeamEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.TeamEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // TeamEvent handles github.TeamEvent.

--- a/githubevents/events_team_add.go
+++ b/githubevents/events_team_add.go
@@ -79,7 +79,10 @@ func (g *EventHandler) handleTeamAddEventAny(ctx context.Context, deliveryID str
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.TeamAddEvent](ctx, deliveryID, eventName, event, g.onTeamAddEvent[TeamAddEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onTeamAddEvent[TeamAddEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.TeamAddEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // TeamAddEvent handles github.TeamAddEvent.

--- a/githubevents/events_watch.go
+++ b/githubevents/events_watch.go
@@ -79,7 +79,10 @@ func (g *EventHandler) handleWatchEventAny(ctx context.Context, deliveryID strin
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.WatchEvent](ctx, deliveryID, eventName, event, g.onWatchEvent[WatchEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onWatchEvent[WatchEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.WatchEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // WatchEvent handles github.WatchEvent.

--- a/githubevents/events_workflow_dispatch.go
+++ b/githubevents/events_workflow_dispatch.go
@@ -79,7 +79,10 @@ func (g *EventHandler) handleWorkflowDispatchEventAny(ctx context.Context, deliv
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.WorkflowDispatchEvent](ctx, deliveryID, eventName, event, g.onWorkflowDispatchEvent[WorkflowDispatchEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onWorkflowDispatchEvent[WorkflowDispatchEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.WorkflowDispatchEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // WorkflowDispatchEvent handles github.WorkflowDispatchEvent.

--- a/githubevents/events_workflow_job.go
+++ b/githubevents/events_workflow_job.go
@@ -98,10 +98,11 @@ func (g *EventHandler) handleWorkflowJobEventQueued(ctx context.Context, deliver
 			*event.Action,
 		)
 	}
-	return dispatch[*github.WorkflowJobEvent](ctx, deliveryID, eventName, event,
-		g.onWorkflowJobEvent[WorkflowJobEventQueuedAction],
-		g.onWorkflowJobEvent[WorkflowJobEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onWorkflowJobEvent[WorkflowJobEventQueuedAction]
+	anyHandlers := g.onWorkflowJobEvent[WorkflowJobEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.WorkflowJobEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnWorkflowJobEventInProgress registers callbacks listening to events of type github.WorkflowJobEvent and action 'in_progress'.
@@ -161,10 +162,11 @@ func (g *EventHandler) handleWorkflowJobEventInProgress(ctx context.Context, del
 			*event.Action,
 		)
 	}
-	return dispatch[*github.WorkflowJobEvent](ctx, deliveryID, eventName, event,
-		g.onWorkflowJobEvent[WorkflowJobEventInProgressAction],
-		g.onWorkflowJobEvent[WorkflowJobEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onWorkflowJobEvent[WorkflowJobEventInProgressAction]
+	anyHandlers := g.onWorkflowJobEvent[WorkflowJobEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.WorkflowJobEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnWorkflowJobEventCompleted registers callbacks listening to events of type github.WorkflowJobEvent and action 'completed'.
@@ -224,10 +226,11 @@ func (g *EventHandler) handleWorkflowJobEventCompleted(ctx context.Context, deli
 			*event.Action,
 		)
 	}
-	return dispatch[*github.WorkflowJobEvent](ctx, deliveryID, eventName, event,
-		g.onWorkflowJobEvent[WorkflowJobEventCompletedAction],
-		g.onWorkflowJobEvent[WorkflowJobEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onWorkflowJobEvent[WorkflowJobEventCompletedAction]
+	anyHandlers := g.onWorkflowJobEvent[WorkflowJobEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.WorkflowJobEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnWorkflowJobEventAny registers callbacks listening to any events of type github.WorkflowJobEvent
@@ -280,7 +283,10 @@ func (g *EventHandler) handleWorkflowJobEventAny(ctx context.Context, deliveryID
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.WorkflowJobEvent](ctx, deliveryID, eventName, event, g.onWorkflowJobEvent[WorkflowJobEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onWorkflowJobEvent[WorkflowJobEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.WorkflowJobEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // WorkflowJobEvent handles github.WorkflowJobEvent.

--- a/githubevents/events_workflow_run.go
+++ b/githubevents/events_workflow_run.go
@@ -94,10 +94,11 @@ func (g *EventHandler) handleWorkflowRunEventRequested(ctx context.Context, deli
 			*event.Action,
 		)
 	}
-	return dispatch[*github.WorkflowRunEvent](ctx, deliveryID, eventName, event,
-		g.onWorkflowRunEvent[WorkflowRunEventRequestedAction],
-		g.onWorkflowRunEvent[WorkflowRunEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onWorkflowRunEvent[WorkflowRunEventRequestedAction]
+	anyHandlers := g.onWorkflowRunEvent[WorkflowRunEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.WorkflowRunEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnWorkflowRunEventCompleted registers callbacks listening to events of type github.WorkflowRunEvent and action 'completed'.
@@ -157,10 +158,11 @@ func (g *EventHandler) handleWorkflowRunEventCompleted(ctx context.Context, deli
 			*event.Action,
 		)
 	}
-	return dispatch[*github.WorkflowRunEvent](ctx, deliveryID, eventName, event,
-		g.onWorkflowRunEvent[WorkflowRunEventCompletedAction],
-		g.onWorkflowRunEvent[WorkflowRunEventAnyAction],
-	)
+	g.mu.RLock()
+	actionHandlers := g.onWorkflowRunEvent[WorkflowRunEventCompletedAction]
+	anyHandlers := g.onWorkflowRunEvent[WorkflowRunEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.WorkflowRunEvent](ctx, deliveryID, eventName, event, actionHandlers, anyHandlers)
 }
 
 // OnWorkflowRunEventAny registers callbacks listening to any events of type github.WorkflowRunEvent
@@ -213,7 +215,10 @@ func (g *EventHandler) handleWorkflowRunEventAny(ctx context.Context, deliveryID
 	if event == nil {
 		return fmt.Errorf("event was empty or nil")
 	}
-	return dispatch[*github.WorkflowRunEvent](ctx, deliveryID, eventName, event, g.onWorkflowRunEvent[WorkflowRunEventAnyAction])
+	g.mu.RLock()
+	anyHandlers := g.onWorkflowRunEvent[WorkflowRunEventAnyAction]
+	g.mu.RUnlock()
+	return dispatch[*github.WorkflowRunEvent](ctx, deliveryID, eventName, event, anyHandlers)
 }
 
 // WorkflowRunEvent handles github.WorkflowRunEvent.

--- a/githubevents/race_test.go
+++ b/githubevents/race_test.go
@@ -1,0 +1,47 @@
+// Copyright 2022 The GithubEvents Authors. All rights reserved.
+// Use of this source code is governed by the MIT License
+// that can be found in the LICENSE file.
+
+package githubevents
+
+import (
+	"context"
+	"sync"
+	"testing"
+
+	"github.com/google/go-github/v90/github"
+)
+
+// Registering a handler while events are being dispatched must not race on the
+// internal handler maps. The read paths take an RLock snapshot; without it the
+// race detector (and sometimes the runtime) flags a concurrent map read/write.
+func TestNoDataRaceRegisterWhileDispatching(t *testing.T) {
+	g := New("")
+	event := &github.LabelEvent{Action: github.Ptr("created")}
+
+	noop := func(ctx context.Context, deliveryID, eventName string, e *github.LabelEvent) error {
+		return nil
+	}
+
+	var wg sync.WaitGroup
+	wg.Add(2)
+
+	// Writer: keeps registering handlers.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			g.OnLabelEventCreated(noop)
+			g.OnLabelEventAny(noop)
+		}
+	}()
+
+	// Reader: keeps dispatching events.
+	go func() {
+		defer wg.Done()
+		for i := 0; i < 200; i++ {
+			_ = g.LabelEvent(context.Background(), "id", "label", event)
+		}
+	}()
+
+	wg.Wait()
+}

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/cbrgm/githubevents/v2
 
-go 1.26.5
+go 1.25.0
 
 require golang.org/x/sync v0.22.0
 


### PR DESCRIPTION
## What

Three runtime-hardening fixes from the post-merge review of `main`.

- **Fix a data race on the handler maps.** Writes (`On*`/`SetOn*`) took `mu.Lock`, but the `handle*` read paths read the maps with no lock, so registering a handler while an event was being dispatched raced on the map (the `RWMutex` only ever guarded writes). The read paths now `RLock`, copy the handler slices, and `RUnlock` before dispatching, so a callback can still register mid-dispatch without deadlocking.
- **Wrap request errors.** `HandleEventRequest` used `%s` + a trailing `\n`, so callers couldn't `errors.Is/As` the underlying go-github error. Now `%w`, no newline.
- **Lower the `go` directive** from the `1.26.5` patch-pin (#275) to `1.25.0`, the actual floor both go-github v90 and x/sync require. `.go-version` still drives the CI toolchain.

Adds a `-race` test and a `make test-race` CI step so this class of bug is caught going forward.

## Why

The race is the real one: the `RWMutex` looked like it protected reads but its `RLock` was never called, so anyone registering handlers concurrently with serving could hit `fatal error: concurrent map read and map write`. The snapshot-under-RLock pattern keeps the lock off the callback execution path (holding it there would deadlock a callback that registers). Behavior is otherwise unchanged: same handlers dispatched, same order, same first-error-wins and panic-recovery semantics. Public API is untouched (apidiff confirms).

## Testing

```
$ CGO_ENABLED=1 go test -race ./githubevents/     # new TestNoDataRace* : was DATA RACE, now ok
ok  github.com/cbrgm/githubevents/v2/githubevents

$ make test        # full suite green, coverage 85.5%
$ make apidiff      # >> API compatible (go-github version-only changes ignored)
$ golangci-lint run # 0 issues
```

The `-race` test fails on `main` (concurrent map read/write) and passes here.

## Checklist
- [x] Tests added/updated (`race_test.go`, run under `-race` in CI via `make test-race`)
- [x] No breaking changes (unexported internals + error wrapping; apidiff compatible; go floor lowered, not raised)
- [x] Readable commit history (3 commits: race fix, error wrap, go directive)
- [x] AI code review considered and comments resolved
