### PR TITLE
chore: update golangci-lint to v2.13.1

### DIFF
--- a/.anvil.lock
+++ b/.anvil.lock
@@ -1,6 +1,6 @@
 {
-  "generated_at": "2026-05-29T13:51:55.435592598Z",
-  "version": "1.3.4",
+  "generated_at": "2026-08-22T14:50:47.423029503Z",
+  "version": "1.3.7",
   "files": [
     {
       "path": ".editorconfig"

--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -2,23 +2,5 @@
     "$schema": "https://docs.renovatebot.com/renovate-schema.json",
     "extends": [
         "github>cbrgm/cbrgm//renovate/preset"
-    ],
-    "postUpdateOptions": [
-        "gomodUpdateImportPaths"
-    ],
-    "customManagers": [
-        {
-            "customType": "regex",
-            "fileMatch": [
-                "^README\\.md$"
-            ],
-            "matchStrings": [
-                "github\\.com/google/go-github/(?<currentValue>v\\d+)/github"
-            ],
-            "depNameTemplate": "google/go-github",
-            "datasourceTemplate": "github-tags",
-            "versioningTemplate": "regex:^v(?<major>\\d+)(\\.(?<minor>\\d+))?(\\.(?<patch>\\d+))?$",
-            "autoReplaceStringTemplate": "github.com/google/go-github/v{{{newMajor}}}/github"
-        }
     ]
 }


### PR DESCRIPTION
chore: update golangci-lint to v2.13.1